### PR TITLE
Add unit tests for Phase 33-38 services (112 new tests)

### DIFF
--- a/tests/lib/achievementService.test.ts
+++ b/tests/lib/achievementService.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  evaluateAchievements,
+  getAchievementSummary,
+  getAchievementCategories,
+  getRecentlyUnlocked,
+  markAsSeen,
+  calculateLevel,
+} from '../../lib/achievementService';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+  };
+})();
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
+
+function makeCard(overrides: Record<string, any> = {}) {
+  return {
+    id: '1',
+    player: 'Test Player',
+    year: 2023,
+    manufacturer: 'Topps',
+    cardNumber: '1',
+    set: 'Chrome',
+    sport: 'Baseball',
+    league: 'MLB',
+    status: 'active',
+    purchasePrice: 100,
+    currentValue: 100,
+    purchaseDate: '2023-06-01',
+    gradingFees: 0,
+    shippingFees: 0,
+    isGraded: false,
+    isAutographed: false,
+    ...overrides,
+  } as any;
+}
+
+describe('achievementService', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('evaluateAchievements', () => {
+    it('returns all achievement definitions', () => {
+      const achievements = evaluateAchievements([]);
+      expect(achievements.length).toBeGreaterThan(30);
+      // Every achievement has required fields
+      for (const a of achievements) {
+        expect(a.id).toBeTruthy();
+        expect(a.name).toBeTruthy();
+        expect(a.category).toBeTruthy();
+        expect(a.tier).toBeTruthy();
+        expect(a.progress).toBeGreaterThanOrEqual(0);
+        expect(a.progress).toBeLessThanOrEqual(100);
+      }
+    });
+
+    it('unlocks first_card with 1 card', () => {
+      const achievements = evaluateAchievements([makeCard()]);
+      const firstCard = achievements.find(a => a.id === 'first_card')!;
+      expect(firstCard.isUnlocked).toBe(true);
+      expect(firstCard.progress).toBe(100);
+    });
+
+    it('nothing unlocked for empty inventory except zero-requirement', () => {
+      const achievements = evaluateAchievements([]);
+      const unlocked = achievements.filter(a => a.isUnlocked);
+      expect(unlocked).toHaveLength(0);
+    });
+
+    it('calculates progress correctly for partial completion', () => {
+      const cards = Array.from({ length: 5 }, (_, i) => makeCard({ id: `c${i}` }));
+      const achievements = evaluateAchievements(cards);
+      const starterPack = achievements.find(a => a.id === 'starter_pack')!;
+      expect(starterPack.progress).toBe(50); // 5/10 = 50%
+      expect(starterPack.isUnlocked).toBe(false);
+    });
+
+    it('unlocks grade_getter for graded cards', () => {
+      const card = makeCard({ isGraded: true, gradingCompany: 'PSA', grade: '10' });
+      const achievements = evaluateAchievements([card]);
+      const gradeGetter = achievements.find(a => a.id === 'grade_getter')!;
+      expect(gradeGetter.isUnlocked).toBe(true);
+    });
+
+    it('unlocks multi_sport with 3 sports', () => {
+      const cards = [
+        makeCard({ id: '1', sport: 'Baseball' }),
+        makeCard({ id: '2', sport: 'Basketball' }),
+        makeCard({ id: '3', sport: 'Football' }),
+      ];
+      const achievements = evaluateAchievements(cards);
+      const multiSport = achievements.find(a => a.id === 'multi_sport')!;
+      expect(multiSport.isUnlocked).toBe(true);
+    });
+
+    it('unlocks first_sale for sold cards', () => {
+      const card = makeCard({ status: 'sold', salePrice: 150 });
+      const achievements = evaluateAchievements([card]);
+      const firstSale = achievements.find(a => a.id === 'first_sale')!;
+      expect(firstSale.isUnlocked).toBe(true);
+    });
+
+    it('unlocks value_surge when card doubles in value', () => {
+      const card = makeCard({ purchasePrice: 50, currentValue: 110 });
+      const achievements = evaluateAchievements([card]);
+      const surge = achievements.find(a => a.id === 'value_surge')!;
+      expect(surge.isUnlocked).toBe(true);
+    });
+
+    it('unlocks perfect_10 for PSA 10', () => {
+      const card = makeCard({ isGraded: true, gradingCompany: 'PSA', grade: '10' });
+      const achievements = evaluateAchievements([card]);
+      const perfect = achievements.find(a => a.id === 'perfect_10')!;
+      expect(perfect.isUnlocked).toBe(true);
+    });
+  });
+
+  describe('getAchievementSummary', () => {
+    it('returns correct summary for empty inventory', () => {
+      const summary = getAchievementSummary([]);
+      expect(summary.totalUnlocked).toBe(0);
+      expect(summary.totalAvailable).toBeGreaterThan(30);
+      expect(summary.completionPercent).toBe(0);
+      expect(summary.pointsEarned).toBe(0);
+      expect(summary.level).toBe(1);
+    });
+
+    it('returns unlocked achievements and points', () => {
+      const cards = Array.from({ length: 10 }, (_, i) => makeCard({ id: `c${i}` }));
+      const summary = getAchievementSummary(cards);
+      expect(summary.totalUnlocked).toBeGreaterThan(0);
+      expect(summary.pointsEarned).toBeGreaterThan(0);
+      expect(summary.completionPercent).toBeGreaterThan(0);
+    });
+
+    it('provides next to unlock suggestions', () => {
+      const summary = getAchievementSummary([makeCard()]);
+      expect(summary.nextToUnlock.length).toBeGreaterThan(0);
+      // Next to unlock should be sorted by progress desc
+      for (let i = 1; i < summary.nextToUnlock.length; i++) {
+        expect(summary.nextToUnlock[i].progress).toBeLessThanOrEqual(
+          summary.nextToUnlock[i - 1].progress
+        );
+      }
+    });
+  });
+
+  describe('getAchievementCategories', () => {
+    it('returns 5 categories', () => {
+      const achievements = evaluateAchievements([]);
+      const categories = getAchievementCategories(achievements);
+      expect(categories).toHaveLength(5);
+      const ids = categories.map(c => c.id);
+      expect(ids).toContain('collection');
+      expect(ids).toContain('trading');
+      expect(ids).toContain('grading');
+      expect(ids).toContain('diversification');
+      expect(ids).toContain('value');
+    });
+
+    it('counts unlocked correctly per category', () => {
+      const cards = Array.from({ length: 10 }, (_, i) => makeCard({ id: `c${i}` }));
+      const achievements = evaluateAchievements(cards);
+      const categories = getAchievementCategories(achievements);
+      const collection = categories.find(c => c.id === 'collection')!;
+      expect(collection.unlockedCount).toBeGreaterThan(0);
+      expect(collection.unlockedCount).toBeLessThanOrEqual(collection.count);
+    });
+  });
+
+  describe('getRecentlyUnlocked', () => {
+    it('returns new unlocks not yet seen', () => {
+      const recent = getRecentlyUnlocked([makeCard()]);
+      // first_card should be in recently unlocked since nothing is seen yet
+      const firstCard = recent.find(a => a.id === 'first_card');
+      expect(firstCard).toBeDefined();
+    });
+
+    it('excludes seen achievements', () => {
+      localStorageMock.setItem('achievement_seen_ids', JSON.stringify(['first_card']));
+      const recent = getRecentlyUnlocked([makeCard()]);
+      const firstCard = recent.find(a => a.id === 'first_card');
+      expect(firstCard).toBeUndefined();
+    });
+  });
+
+  describe('markAsSeen', () => {
+    it('adds achievement to seen list', () => {
+      markAsSeen('first_card');
+      const stored = JSON.parse(localStorageMock.getItem('achievement_seen_ids')!);
+      expect(stored).toContain('first_card');
+    });
+
+    it('accumulates seen ids', () => {
+      markAsSeen('first_card');
+      markAsSeen('starter_pack');
+      const stored = JSON.parse(localStorageMock.getItem('achievement_seen_ids')!);
+      expect(stored).toContain('first_card');
+      expect(stored).toContain('starter_pack');
+    });
+  });
+
+  describe('calculateLevel', () => {
+    it('returns level 1 for 0 points', () => {
+      const { level, levelProgress } = calculateLevel(0);
+      expect(level).toBe(1);
+    });
+
+    it('returns level 1 for small points', () => {
+      const { level } = calculateLevel(5);
+      expect(level).toBe(1);
+    });
+
+    it('increases level with more points', () => {
+      const l1 = calculateLevel(10);
+      const l2 = calculateLevel(100);
+      const l3 = calculateLevel(1000);
+      expect(l2.level).toBeGreaterThanOrEqual(l1.level);
+      expect(l3.level).toBeGreaterThan(l2.level);
+    });
+
+    it('caps at level 50', () => {
+      const { level } = calculateLevel(1000000);
+      expect(level).toBe(50);
+    });
+
+    it('level progress is between 0 and 100', () => {
+      for (const pts of [0, 10, 50, 100, 500, 1000]) {
+        const { levelProgress } = calculateLevel(pts);
+        expect(levelProgress).toBeGreaterThanOrEqual(0);
+        expect(levelProgress).toBeLessThanOrEqual(100);
+      }
+    });
+  });
+});

--- a/tests/lib/anomalyDetectionService.test.ts
+++ b/tests/lib/anomalyDetectionService.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  calculateZScore,
+  detectAnomalies,
+  findArbitrageOpportunities,
+  getAnomalySummary,
+  acknowledgeAnomaly,
+  getAnomalyHistory,
+  getAnomalyTrend,
+} from '../../lib/anomalyDetectionService';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+  };
+})();
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
+
+function makeCard(overrides: Record<string, any> = {}) {
+  return {
+    id: '1',
+    player: 'Test Player',
+    year: 2023,
+    manufacturer: 'Topps',
+    cardNumber: '1',
+    set: 'Chrome',
+    sport: 'Baseball',
+    league: 'MLB',
+    status: 'active',
+    purchasePrice: 100,
+    currentValue: 100,
+    purchaseDate: '2023-06-01',
+    gradingFees: 0,
+    shippingFees: 0,
+    ...overrides,
+  } as any;
+}
+
+describe('anomalyDetectionService', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('calculateZScore', () => {
+    it('returns 0 when stdDev is 0', () => {
+      expect(calculateZScore(10, 10, 0)).toBe(0);
+    });
+
+    it('calculates positive z-score correctly', () => {
+      expect(calculateZScore(120, 100, 10)).toBe(2);
+    });
+
+    it('calculates negative z-score correctly', () => {
+      expect(calculateZScore(80, 100, 10)).toBe(-2);
+    });
+
+    it('returns 0 when value equals mean', () => {
+      expect(calculateZScore(50, 50, 5)).toBe(0);
+    });
+  });
+
+  describe('detectAnomalies', () => {
+    it('returns empty array for empty inventory', () => {
+      const anomalies = detectAnomalies([]);
+      expect(anomalies).toEqual([]);
+    });
+
+    it('detects price spike when value > 1.5x purchase and owned < 90 days', () => {
+      const recentDate = new Date();
+      recentDate.setDate(recentDate.getDate() - 30);
+      const card = makeCard({
+        purchasePrice: 100,
+        currentValue: 200,
+        purchaseDate: recentDate.toISOString(),
+      });
+      const anomalies = detectAnomalies([card]);
+      const spikes = anomalies.filter(a => a.type === 'spike');
+      expect(spikes.length).toBeGreaterThanOrEqual(1);
+      expect(spikes[0].player).toBe('Test Player');
+    });
+
+    it('detects price crash when value < 0.6x purchase', () => {
+      const card = makeCard({
+        purchasePrice: 100,
+        currentValue: 40,
+      });
+      const anomalies = detectAnomalies([card]);
+      const crashes = anomalies.filter(a => a.type === 'crash');
+      expect(crashes.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('detects stale pricing when valuation is old', () => {
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 60);
+      const card = makeCard({
+        lastValuationDate: oldDate.toISOString(),
+      });
+      const anomalies = detectAnomalies([card]);
+      const stale = anomalies.filter(a => a.type === 'stale_price');
+      expect(stale.length).toBe(1);
+      expect(['low', 'medium']).toContain(stale[0].severity);
+    });
+
+    it('assigns severity based on deviation percent', () => {
+      const card = makeCard({
+        purchasePrice: 100,
+        currentValue: 20, // -80% crash
+      });
+      const anomalies = detectAnomalies([card]);
+      const crash = anomalies.find(a => a.type === 'crash');
+      expect(crash).toBeDefined();
+      expect(crash!.severity).toBe('critical');
+    });
+
+    it('preserves acknowledged status from stored anomalies', () => {
+      // Pre-store an acknowledged anomaly
+      localStorageMock.setItem(
+        'msi_anomalies',
+        JSON.stringify([{ id: 'crash-1', isAcknowledged: true }])
+      );
+      const card = makeCard({
+        id: '1',
+        purchasePrice: 100,
+        currentValue: 40,
+      });
+      const anomalies = detectAnomalies([card]);
+      const crash = anomalies.find(a => a.id === 'crash-1');
+      if (crash) {
+        expect(crash.isAcknowledged).toBe(true);
+      }
+    });
+  });
+
+  describe('findArbitrageOpportunities', () => {
+    it('returns empty for empty inventory', () => {
+      expect(findArbitrageOpportunities([])).toEqual([]);
+    });
+
+    it('generates opportunities for some cards (deterministic)', () => {
+      const inventory = Array.from({ length: 20 }, (_, i) =>
+        makeCard({ id: `card-${i}`, player: `Player ${i}`, currentValue: 100 + i * 10 })
+      );
+      const opps = findArbitrageOpportunities(inventory);
+      // ~25% of 20 cards = ~5, but deterministic so at least some
+      expect(opps.length).toBeGreaterThan(0);
+    });
+
+    it('each opportunity has valid spread', () => {
+      const inventory = Array.from({ length: 10 }, (_, i) =>
+        makeCard({ id: `card-${i}`, player: `Player ${i}`, currentValue: 200 })
+      );
+      const opps = findArbitrageOpportunities(inventory);
+      for (const opp of opps) {
+        expect(opp.sellPrice).toBeGreaterThan(opp.buyPrice);
+        expect(opp.spread).toBeGreaterThan(0);
+        expect(opp.spreadPercent).toBeGreaterThan(0);
+        expect(opp.buySource).not.toBe(opp.sellSource);
+      }
+    });
+
+    it('sorts by spread descending', () => {
+      const inventory = Array.from({ length: 20 }, (_, i) =>
+        makeCard({ id: `card-${i}`, player: `Player ${i}`, currentValue: 50 + i * 20 })
+      );
+      const opps = findArbitrageOpportunities(inventory);
+      for (let i = 1; i < opps.length; i++) {
+        expect(opps[i].spread).toBeLessThanOrEqual(opps[i - 1].spread);
+      }
+    });
+  });
+
+  describe('getAnomalySummary', () => {
+    it('returns zeroed summary for empty inventory', () => {
+      const summary = getAnomalySummary([]);
+      expect(summary.totalActive).toBe(0);
+      expect(summary.criticalCount).toBe(0);
+      expect(summary.totalArbitrageValue).toBe(0);
+      expect(summary.mostAnomalousCard).toBe('None');
+    });
+
+    it('counts severity levels correctly', () => {
+      const inventory = [
+        makeCard({ id: '1', purchasePrice: 100, currentValue: 20 }), // crash, critical
+        makeCard({ id: '2', purchasePrice: 100, currentValue: 100 }), // normal
+      ];
+      const summary = getAnomalySummary(inventory);
+      expect(summary.totalActive).toBeGreaterThan(0);
+    });
+  });
+
+  describe('acknowledgeAnomaly', () => {
+    it('marks an anomaly as acknowledged in storage', () => {
+      localStorageMock.setItem(
+        'msi_anomalies',
+        JSON.stringify([
+          { id: 'a1', isAcknowledged: false },
+          { id: 'a2', isAcknowledged: false },
+        ])
+      );
+      acknowledgeAnomaly('a1');
+      const stored = JSON.parse(localStorageMock.getItem('msi_anomalies')!);
+      expect(stored.find((a: any) => a.id === 'a1').isAcknowledged).toBe(true);
+      expect(stored.find((a: any) => a.id === 'a2').isAcknowledged).toBe(false);
+    });
+  });
+
+  describe('getAnomalyHistory', () => {
+    it('returns empty array when no stored data', () => {
+      expect(getAnomalyHistory()).toEqual([]);
+    });
+
+    it('returns stored anomalies', () => {
+      localStorageMock.setItem('msi_anomalies', JSON.stringify([{ id: 'x' }]));
+      expect(getAnomalyHistory()).toHaveLength(1);
+    });
+  });
+
+  describe('getAnomalyTrend', () => {
+    it('returns a valid trend value', () => {
+      const trend = getAnomalyTrend([]);
+      expect(['increasing', 'decreasing', 'stable']).toContain(trend);
+    });
+
+    it('is deterministic for same input', () => {
+      const inv = [makeCard()];
+      const t1 = getAnomalyTrend(inv);
+      const t2 = getAnomalyTrend(inv);
+      expect(t1).toBe(t2);
+    });
+  });
+});

--- a/tests/lib/auctionSniperService.test.ts
+++ b/tests/lib/auctionSniperService.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  generateMockAuctions,
+  analyzeListing,
+  calculateOptimalBid,
+  getAuctionAlerts,
+  getBidTimingRecommendation,
+  getAuctionStats,
+  getWatchedAuctions,
+  watchAuction,
+  unwatchAuction,
+  isAuctionWatched,
+} from '../../lib/auctionSniperService';
+import type { AuctionListing } from '../../lib/auctionSniperService';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+  };
+})();
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
+
+function makeCard(overrides: Record<string, any> = {}) {
+  return {
+    id: '1',
+    player: 'Test Player',
+    year: 2023,
+    manufacturer: 'Topps',
+    cardNumber: '1',
+    set: 'Chrome',
+    sport: 'Baseball',
+    league: 'MLB',
+    status: 'active',
+    purchasePrice: 100,
+    currentValue: 150,
+    purchaseDate: '2023-06-01',
+    ...overrides,
+  } as any;
+}
+
+function makeListing(overrides: Partial<AuctionListing> = {}): AuctionListing {
+  return {
+    id: 'auction-1',
+    player: 'Mike Trout',
+    year: 2023,
+    manufacturer: 'Topps',
+    set: 'Chrome',
+    sport: 'Baseball',
+    grade: 'PSA 10',
+    currentBid: 80,
+    bidCount: 5,
+    startPrice: 50,
+    estimatedValue: 200,
+    timeRemaining: 7200,
+    endTime: new Date(Date.now() + 7200000).toISOString(),
+    seller: 'cardking99',
+    condition: 'Gem Mint',
+    image: '',
+    watchers: 10,
+    isHot: false,
+    ...overrides,
+  };
+}
+
+describe('auctionSniperService', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('generateMockAuctions', () => {
+    it('generates 8-12 listings', () => {
+      const listings = generateMockAuctions([]);
+      expect(listings.length).toBeGreaterThanOrEqual(8);
+      expect(listings.length).toBeLessThanOrEqual(12);
+    });
+
+    it('is deterministic (same results for same day)', () => {
+      const a = generateMockAuctions([]);
+      const b = generateMockAuctions([]);
+      expect(a.length).toBe(b.length);
+      expect(a[0].player).toBe(b[0].player);
+    });
+
+    it('incorporates inventory cards', () => {
+      const inventory = Array.from({ length: 10 }, (_, i) =>
+        makeCard({ id: `c${i}`, player: `Inv Player ${i}` })
+      );
+      const listings = generateMockAuctions(inventory);
+      // At least some listings may use inventory players
+      expect(listings.length).toBeGreaterThanOrEqual(8);
+    });
+
+    it('all listings have positive values', () => {
+      const listings = generateMockAuctions([]);
+      for (const l of listings) {
+        expect(l.estimatedValue).toBeGreaterThan(0);
+        expect(l.currentBid).toBeGreaterThan(0);
+        expect(l.timeRemaining).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+
+  describe('analyzeListing', () => {
+    it('recommends snipe for ending-soon low-bid auctions', () => {
+      const listing = makeListing({
+        timeRemaining: 600, // 10 min
+        bidCount: 3,
+        currentBid: 80,
+        estimatedValue: 200,
+        watchers: 2,
+      });
+      const analysis = analyzeListing(listing);
+      expect(analysis.strategy).toBe('snipe');
+      expect(analysis.riskLevel).toBe('low');
+    });
+
+    it('recommends skip when bid is at fair value', () => {
+      const listing = makeListing({
+        currentBid: 195,
+        estimatedValue: 200,
+      });
+      const analysis = analyzeListing(listing);
+      expect(analysis.strategy).toBe('skip');
+    });
+
+    it('recommends early_bid for undervalued low-watcher listings', () => {
+      const listing = makeListing({
+        currentBid: 60,
+        estimatedValue: 200,
+        watchers: 3,
+        timeRemaining: 86400,
+        bidCount: 2,
+      });
+      const analysis = analyzeListing(listing);
+      expect(analysis.strategy).toBe('early_bid');
+    });
+
+    it('returns valid confidence between 0 and 100', () => {
+      const listing = makeListing();
+      const analysis = analyzeListing(listing);
+      expect(analysis.confidence).toBeGreaterThanOrEqual(0);
+      expect(analysis.confidence).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('calculateOptimalBid', () => {
+    it('returns 85% of value for low competition', () => {
+      const listing = makeListing({
+        bidCount: 1,
+        watchers: 2,
+        estimatedValue: 100,
+        currentBid: 10,
+      });
+      const bid = calculateOptimalBid(listing);
+      expect(bid).toBeCloseTo(85, 0);
+    });
+
+    it('never returns below current bid + 0.50', () => {
+      const listing = makeListing({
+        currentBid: 195,
+        estimatedValue: 200,
+        bidCount: 0,
+        watchers: 0,
+      });
+      const bid = calculateOptimalBid(listing);
+      expect(bid).toBeGreaterThanOrEqual(195.50);
+    });
+
+    it('bids higher for fierce competition', () => {
+      const lowComp = makeListing({ bidCount: 1, watchers: 2, estimatedValue: 200, currentBid: 50 });
+      const highComp = makeListing({ bidCount: 20, watchers: 30, estimatedValue: 200, currentBid: 50 });
+      const lowBid = calculateOptimalBid(lowComp);
+      const highBid = calculateOptimalBid(highComp);
+      expect(highBid).toBeGreaterThan(lowBid);
+    });
+  });
+
+  describe('getAuctionAlerts', () => {
+    it('returns ending_soon alerts for auctions under 1 hour', () => {
+      const listings = [makeListing({ timeRemaining: 300 })]; // 5 min
+      const alerts = getAuctionAlerts(listings);
+      const endingSoon = alerts.filter(a => a.type === 'ending_soon');
+      expect(endingSoon.length).toBe(1);
+      expect(endingSoon[0].severity).toBe('critical'); // < 600s
+    });
+
+    it('returns below_value alerts', () => {
+      const listings = [makeListing({ currentBid: 50, estimatedValue: 200 })]; // 75% below
+      const alerts = getAuctionAlerts(listings);
+      const belowValue = alerts.filter(a => a.type === 'below_value');
+      expect(belowValue.length).toBe(1);
+    });
+
+    it('returns no ending_soon for auctions with plenty of time', () => {
+      const listings = [makeListing({ timeRemaining: 86400 })]; // 1 day
+      const alerts = getAuctionAlerts(listings);
+      const endingSoon = alerts.filter(a => a.type === 'ending_soon');
+      expect(endingSoon).toHaveLength(0);
+    });
+  });
+
+  describe('getBidTimingRecommendation', () => {
+    it('returns 30 for low competition', () => {
+      const listing = makeListing({ bidCount: 1, watchers: 2 });
+      expect(getBidTimingRecommendation(listing)).toBe(30);
+    });
+
+    it('returns 3 for fierce competition', () => {
+      const listing = makeListing({ bidCount: 20, watchers: 30 });
+      expect(getBidTimingRecommendation(listing)).toBe(3);
+    });
+  });
+
+  describe('getAuctionStats', () => {
+    it('returns zeros for empty listings', () => {
+      const stats = getAuctionStats([]);
+      expect(stats.totalActive).toBe(0);
+      expect(stats.endingSoon).toBe(0);
+      expect(stats.avgDiscount).toBe(0);
+      expect(stats.totalPotentialSavings).toBe(0);
+    });
+
+    it('calculates stats correctly', () => {
+      const listings = [
+        makeListing({ timeRemaining: 300, currentBid: 100, estimatedValue: 200 }),
+        makeListing({ timeRemaining: 86400, currentBid: 150, estimatedValue: 200 }),
+      ];
+      const stats = getAuctionStats(listings);
+      expect(stats.totalActive).toBe(2);
+      expect(stats.endingSoon).toBe(1);
+      expect(stats.totalPotentialSavings).toBe(150);
+      expect(stats.avgDiscount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('watch list persistence', () => {
+    it('starts with empty watch list', () => {
+      expect(getWatchedAuctions()).toEqual([]);
+    });
+
+    it('watches and unwatches auctions', () => {
+      watchAuction('a1');
+      watchAuction('a2');
+      expect(getWatchedAuctions()).toEqual(['a1', 'a2']);
+      expect(isAuctionWatched('a1')).toBe(true);
+
+      unwatchAuction('a1');
+      expect(getWatchedAuctions()).toEqual(['a2']);
+      expect(isAuctionWatched('a1')).toBe(false);
+    });
+
+    it('does not duplicate watched auctions', () => {
+      watchAuction('a1');
+      watchAuction('a1');
+      expect(getWatchedAuctions()).toEqual(['a1']);
+    });
+  });
+});

--- a/tests/lib/priceChartService.test.ts
+++ b/tests/lib/priceChartService.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generatePriceHistory,
+  calculateStatistics,
+  getAnnotations,
+  calculateMovingAverage,
+  calculateBollingerBands,
+  detectTrendline,
+  getSupportResistance,
+} from '../../lib/priceChartService';
+
+function makeCard(overrides: Record<string, any> = {}) {
+  return {
+    id: 'card-1',
+    player: 'Mike Trout',
+    year: 2023,
+    manufacturer: 'Topps',
+    cardNumber: '1',
+    set: 'Chrome',
+    sport: 'Baseball',
+    league: 'MLB',
+    status: 'active',
+    purchasePrice: 100,
+    currentValue: 150,
+    purchaseDate: '2024-01-01',
+    gradingFees: 0,
+    shippingFees: 0,
+    ...overrides,
+  } as any;
+}
+
+describe('priceChartService', () => {
+  describe('generatePriceHistory', () => {
+    it('generates data points for 1W range', () => {
+      const data = generatePriceHistory(makeCard(), '1W');
+      expect(data.length).toBeGreaterThan(0);
+      expect(data.length).toBeLessThanOrEqual(8); // ~7 days
+    });
+
+    it('generates more points for longer ranges', () => {
+      const week = generatePriceHistory(makeCard(), '1W');
+      const year = generatePriceHistory(makeCard(), '1Y');
+      expect(year.length).toBeGreaterThan(week.length);
+    });
+
+    it('last data point price equals currentValue', () => {
+      const card = makeCard({ currentValue: 200 });
+      const data = generatePriceHistory(card, '1M');
+      expect(data[data.length - 1].price).toBe(200);
+    });
+
+    it('all prices are positive', () => {
+      const data = generatePriceHistory(makeCard(), '3M');
+      for (const point of data) {
+        expect(point.price).toBeGreaterThan(0);
+        expect(point.high).toBeGreaterThan(0);
+        expect(point.low).toBeGreaterThan(0);
+      }
+    });
+
+    it('is deterministic for same card and range', () => {
+      const card = makeCard();
+      const a = generatePriceHistory(card, '1M');
+      const b = generatePriceHistory(card, '1M');
+      expect(a.length).toBe(b.length);
+      expect(a[0].price).toBe(b[0].price);
+    });
+
+    it('includes date strings in ISO format', () => {
+      const data = generatePriceHistory(makeCard(), '1M');
+      for (const point of data) {
+        expect(point.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      }
+    });
+  });
+
+  describe('calculateStatistics', () => {
+    it('returns zeros for empty data', () => {
+      const stats = calculateStatistics([]);
+      expect(stats.currentPrice).toBe(0);
+      expect(stats.allTimeHigh).toBe(0);
+      expect(stats.volatility).toBe(0);
+    });
+
+    it('calculates basic stats correctly', () => {
+      const data = generatePriceHistory(makeCard({ purchasePrice: 100, currentValue: 150 }), '3M');
+      const stats = calculateStatistics(data);
+      expect(stats.currentPrice).toBe(150);
+      expect(stats.allTimeHigh).toBeGreaterThanOrEqual(stats.currentPrice);
+      expect(stats.allTimeLow).toBeLessThanOrEqual(stats.currentPrice);
+      expect(stats.allTimeHigh).toBeGreaterThanOrEqual(stats.allTimeLow);
+      expect(stats.avgPrice).toBeGreaterThan(0);
+    });
+
+    it('calculates positive price change for appreciating card', () => {
+      const data = generatePriceHistory(makeCard({ purchasePrice: 50, currentValue: 100 }), '1Y');
+      const stats = calculateStatistics(data);
+      expect(stats.priceChange).toBeGreaterThan(0);
+      expect(stats.priceChangePct).toBeGreaterThan(0);
+    });
+
+    it('max drawdown is non-negative', () => {
+      const data = generatePriceHistory(makeCard(), '6M');
+      const stats = calculateStatistics(data);
+      expect(stats.maxDrawdown).toBeGreaterThanOrEqual(0);
+      expect(stats.maxDrawdownPct).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('getAnnotations', () => {
+    it('includes purchase annotation', () => {
+      const card = makeCard({ purchaseDate: '2024-01-15', purchasePrice: 100 });
+      const annotations = getAnnotations(card);
+      const purchase = annotations.find(a => a.type === 'purchase');
+      expect(purchase).toBeDefined();
+      expect(purchase!.date).toBe('2024-01-15');
+    });
+
+    it('includes sale annotation when card is sold', () => {
+      const card = makeCard({
+        status: 'sold',
+        saleDate: '2024-06-01',
+        salePrice: 200,
+      });
+      const annotations = getAnnotations(card);
+      const sale = annotations.find(a => a.type === 'sale');
+      expect(sale).toBeDefined();
+    });
+
+    it('includes grade annotation for graded cards', () => {
+      const card = makeCard({
+        isGraded: true,
+        gradingCompany: 'PSA',
+        grade: '10',
+      });
+      const annotations = getAnnotations(card);
+      const grade = annotations.find(a => a.type === 'grade');
+      expect(grade).toBeDefined();
+      expect(grade!.label).toContain('PSA 10');
+    });
+
+    it('includes milestone for doubled value', () => {
+      const card = makeCard({ purchasePrice: 50, currentValue: 120 });
+      const annotations = getAnnotations(card);
+      const milestone = annotations.find(a => a.type === 'milestone');
+      expect(milestone).toBeDefined();
+      expect(milestone!.label).toContain('2x');
+    });
+  });
+
+  describe('calculateMovingAverage', () => {
+    it('returns null for points before the period', () => {
+      const data = generatePriceHistory(makeCard(), '1M');
+      const ma = calculateMovingAverage(data, 7);
+      for (let i = 0; i < 6; i++) {
+        expect(ma[i].ma).toBeNull();
+      }
+      expect(ma[6].ma).not.toBeNull();
+    });
+
+    it('calculates correct moving average', () => {
+      const data = [
+        { date: '2024-01-01', price: 10, volume: 1, high: 11, low: 9, source: 'market' as const },
+        { date: '2024-01-02', price: 20, volume: 1, high: 21, low: 19, source: 'market' as const },
+        { date: '2024-01-03', price: 30, volume: 1, high: 31, low: 29, source: 'market' as const },
+      ];
+      const ma = calculateMovingAverage(data, 3);
+      expect(ma[2].ma).toBe(20); // (10+20+30)/3
+    });
+  });
+
+  describe('calculateBollingerBands', () => {
+    it('returns null bands before the period', () => {
+      const data = generatePriceHistory(makeCard(), '3M');
+      const bb = calculateBollingerBands(data, 20);
+      for (let i = 0; i < 19; i++) {
+        expect(bb[i].upper).toBeNull();
+        expect(bb[i].lower).toBeNull();
+        expect(bb[i].middle).toBeNull();
+      }
+    });
+
+    it('upper > middle > lower after period', () => {
+      const data = generatePriceHistory(makeCard(), '3M');
+      const bb = calculateBollingerBands(data, 20);
+      const valid = bb.filter(b => b.upper !== null);
+      for (const b of valid) {
+        expect(b.upper!).toBeGreaterThanOrEqual(b.middle!);
+        expect(b.middle!).toBeGreaterThanOrEqual(b.lower!);
+      }
+    });
+  });
+
+  describe('detectTrendline', () => {
+    it('returns zero slope for constant prices', () => {
+      const data = Array.from({ length: 10 }, (_, i) => ({
+        date: `2024-01-${String(i + 1).padStart(2, '0')}`,
+        price: 100,
+        volume: 1,
+        high: 100,
+        low: 100,
+        source: 'market' as const,
+      }));
+      const trend = detectTrendline(data);
+      expect(trend.slope).toBe(0);
+      expect(trend.intercept).toBe(100);
+    });
+
+    it('returns positive slope for increasing prices', () => {
+      const data = Array.from({ length: 10 }, (_, i) => ({
+        date: `2024-01-${String(i + 1).padStart(2, '0')}`,
+        price: 100 + i * 10,
+        volume: 1,
+        high: 100 + i * 10,
+        low: 100 + i * 10,
+        source: 'market' as const,
+      }));
+      const trend = detectTrendline(data);
+      expect(trend.slope).toBeGreaterThan(0);
+    });
+
+    it('handles single data point', () => {
+      const data = [{ date: '2024-01-01', price: 50, volume: 1, high: 50, low: 50, source: 'market' as const }];
+      const trend = detectTrendline(data);
+      expect(trend.slope).toBe(0);
+      expect(trend.intercept).toBe(50);
+    });
+  });
+
+  describe('getSupportResistance', () => {
+    it('returns zeros for empty data', () => {
+      const sr = getSupportResistance([]);
+      expect(sr.support).toBe(0);
+      expect(sr.resistance).toBe(0);
+    });
+
+    it('support <= resistance', () => {
+      const data = generatePriceHistory(makeCard(), '3M');
+      const sr = getSupportResistance(data);
+      expect(sr.support).toBeLessThanOrEqual(sr.resistance);
+    });
+
+    it('support and resistance are within price range', () => {
+      const data = generatePriceHistory(makeCard(), '3M');
+      const prices = data.map(d => d.price);
+      const sr = getSupportResistance(data);
+      expect(sr.support).toBeGreaterThanOrEqual(Math.min(...prices));
+      expect(sr.resistance).toBeLessThanOrEqual(Math.max(...prices));
+    });
+  });
+});

--- a/tests/lib/rebalancingAlertService.test.ts
+++ b/tests/lib/rebalancingAlertService.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  calculatePortfolioDrift,
+  generateRebalanceAlerts,
+  getRebalanceSuggestions,
+  calculateRebalanceCost,
+  getPortfolioHealth,
+  getDefaultTargets,
+  getDefaultConfig,
+  getAlertHistory,
+  saveAlertHistory,
+  acknowledgeAlert,
+  persistAlerts,
+} from '../../lib/rebalancingAlertService';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+  };
+})();
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
+
+function makeCard(overrides: Record<string, any> = {}) {
+  return {
+    id: '1',
+    player: 'Test Player',
+    year: 2023,
+    manufacturer: 'Topps',
+    cardNumber: '1',
+    set: 'Chrome',
+    sport: 'Baseball',
+    league: 'MLB',
+    status: 'active',
+    purchasePrice: 100,
+    currentValue: 100,
+    purchaseDate: '2023-06-01',
+    gradingFees: 0,
+    shippingFees: 0,
+    ...overrides,
+  } as any;
+}
+
+describe('rebalancingAlertService', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('getDefaultTargets', () => {
+    it('returns targets for all 5 sports', () => {
+      const targets = getDefaultTargets();
+      expect(targets).toHaveLength(5);
+      const sports = targets.map(t => t.sport);
+      expect(sports).toContain('Baseball');
+      expect(sports).toContain('Basketball');
+      expect(sports).toContain('Football');
+      expect(sports).toContain('Hockey');
+      expect(sports).toContain('Soccer');
+    });
+
+    it('targets sum to 100%', () => {
+      const total = getDefaultTargets().reduce((s, t) => s + t.targetPercent, 0);
+      expect(total).toBe(100);
+    });
+  });
+
+  describe('getDefaultConfig', () => {
+    it('returns a valid config', () => {
+      const config = getDefaultConfig();
+      expect(config.checkFrequency).toBe('weekly');
+      expect(config.autoAcknowledge).toBe(false);
+      expect(config.targets).toHaveLength(5);
+    });
+  });
+
+  describe('calculatePortfolioDrift', () => {
+    it('returns zeros for empty inventory', () => {
+      const drifts = calculatePortfolioDrift([]);
+      expect(drifts).toHaveLength(5);
+      for (const d of drifts) {
+        expect(d.actualPercent).toBe(0);
+        expect(d.cardCount).toBe(0);
+        expect(d.totalValue).toBe(0);
+      }
+    });
+
+    it('calculates 100% allocation for single-sport portfolio', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 200 }),
+        makeCard({ id: '2', sport: 'Baseball', currentValue: 300 }),
+      ];
+      const drifts = calculatePortfolioDrift(inventory);
+      const baseball = drifts.find(d => d.sport === 'Baseball')!;
+      expect(baseball.actualPercent).toBe(100);
+      expect(baseball.cardCount).toBe(2);
+      expect(baseball.totalValue).toBe(500);
+      // 100% actual - 25% target = 75% drift
+      expect(baseball.driftAmount).toBe(75);
+    });
+
+    it('excludes sold cards', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 200, status: 'active' }),
+        makeCard({ id: '2', sport: 'Baseball', currentValue: 300, status: 'sold' }),
+      ];
+      const drifts = calculatePortfolioDrift(inventory);
+      const baseball = drifts.find(d => d.sport === 'Baseball')!;
+      expect(baseball.cardCount).toBe(1);
+      expect(baseball.totalValue).toBe(200);
+    });
+
+    it('calculates balanced portfolio with low drift', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 250 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 250 }),
+        makeCard({ id: '3', sport: 'Football', currentValue: 250 }),
+        makeCard({ id: '4', sport: 'Hockey', currentValue: 150 }),
+        makeCard({ id: '5', sport: 'Soccer', currentValue: 100 }),
+      ];
+      const drifts = calculatePortfolioDrift(inventory);
+      // Each sport should be close to target
+      for (const d of drifts) {
+        expect(d.absDrift).toBeLessThan(1);
+      }
+    });
+  });
+
+  describe('generateRebalanceAlerts', () => {
+    it('returns no alerts for balanced portfolio', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 250 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 250 }),
+        makeCard({ id: '3', sport: 'Football', currentValue: 250 }),
+        makeCard({ id: '4', sport: 'Hockey', currentValue: 150 }),
+        makeCard({ id: '5', sport: 'Soccer', currentValue: 100 }),
+      ];
+      const alerts = generateRebalanceAlerts(inventory);
+      const driftAlerts = alerts.filter(a => a.type === 'drift');
+      expect(driftAlerts).toHaveLength(0);
+    });
+
+    it('generates drift alerts when allocation exceeds tolerance', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 900 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 100 }),
+      ];
+      const alerts = generateRebalanceAlerts(inventory);
+      const driftAlerts = alerts.filter(a => a.type === 'drift');
+      expect(driftAlerts.length).toBeGreaterThan(0);
+    });
+
+    it('generates concentration alert when sport exceeds 50%', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 600 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 100 }),
+        makeCard({ id: '3', sport: 'Football', currentValue: 100 }),
+        makeCard({ id: '4', sport: 'Hockey', currentValue: 100 }),
+        makeCard({ id: '5', sport: 'Soccer', currentValue: 100 }),
+      ];
+      const alerts = generateRebalanceAlerts(inventory);
+      const concentrationAlerts = alerts.filter(a => a.type === 'concentration');
+      expect(concentrationAlerts.length).toBe(1);
+      expect(concentrationAlerts[0].sport).toBe('Baseball');
+      expect(concentrationAlerts[0].severity).toBe('critical');
+    });
+
+    it('sorts alerts by severity (critical first)', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 900 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 100 }),
+      ];
+      const alerts = generateRebalanceAlerts(inventory);
+      if (alerts.length >= 2) {
+        const severityOrder = { critical: 0, warning: 1, info: 2 };
+        for (let i = 1; i < alerts.length; i++) {
+          expect(severityOrder[alerts[i].severity]).toBeGreaterThanOrEqual(
+            severityOrder[alerts[i - 1].severity]
+          );
+        }
+      }
+    });
+  });
+
+  describe('getRebalanceSuggestions', () => {
+    it('returns empty for balanced portfolio', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 250 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 250 }),
+        makeCard({ id: '3', sport: 'Football', currentValue: 250 }),
+        makeCard({ id: '4', sport: 'Hockey', currentValue: 150 }),
+        makeCard({ id: '5', sport: 'Soccer', currentValue: 100 }),
+      ];
+      const suggestions = getRebalanceSuggestions(inventory);
+      expect(suggestions).toHaveLength(0);
+    });
+
+    it('suggests sell for overallocated and buy for underallocated sports', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 800 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 200 }),
+      ];
+      const suggestions = getRebalanceSuggestions(inventory);
+      const sellSuggestions = suggestions.filter(s => s.action === 'sell');
+      const buySuggestions = suggestions.filter(s => s.action === 'buy');
+      expect(sellSuggestions.length).toBeGreaterThan(0);
+      expect(buySuggestions.length).toBeGreaterThan(0);
+    });
+
+    it('sorts by priority', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 900 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 100 }),
+      ];
+      const suggestions = getRebalanceSuggestions(inventory);
+      for (let i = 1; i < suggestions.length; i++) {
+        expect(suggestions[i].priority).toBeGreaterThanOrEqual(suggestions[i - 1].priority);
+      }
+    });
+  });
+
+  describe('calculateRebalanceCost', () => {
+    it('returns zeros for balanced portfolio', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 250 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 250 }),
+        makeCard({ id: '3', sport: 'Football', currentValue: 250 }),
+        makeCard({ id: '4', sport: 'Hockey', currentValue: 150 }),
+        makeCard({ id: '5', sport: 'Soccer', currentValue: 100 }),
+      ];
+      const cost = calculateRebalanceCost(inventory);
+      expect(cost.totalCost).toBe(0);
+      expect(cost.sellTransactionFees).toBe(0);
+      expect(cost.buyTransactionFees).toBe(0);
+    });
+
+    it('calculates fees for imbalanced portfolio', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 900 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 100 }),
+      ];
+      const cost = calculateRebalanceCost(inventory);
+      expect(cost.totalCost).toBeGreaterThan(0);
+      expect(cost.netRebalanceValue).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getPortfolioHealth', () => {
+    it('returns perfect score for balanced portfolio', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 250 }),
+        makeCard({ id: '2', sport: 'Basketball', currentValue: 250 }),
+        makeCard({ id: '3', sport: 'Football', currentValue: 250 }),
+        makeCard({ id: '4', sport: 'Hockey', currentValue: 150 }),
+        makeCard({ id: '5', sport: 'Soccer', currentValue: 100 }),
+      ];
+      const health = getPortfolioHealth(inventory);
+      expect(health.score).toBeGreaterThanOrEqual(90);
+      expect(health.label).toBe('Excellent');
+      expect(health.totalCards).toBe(5);
+      expect(health.totalValue).toBe(1000);
+    });
+
+    it('returns low score for heavily imbalanced portfolio', () => {
+      const inventory = [
+        makeCard({ id: '1', sport: 'Baseball', currentValue: 1000 }),
+      ];
+      const health = getPortfolioHealth(inventory);
+      expect(health.score).toBeLessThan(60);
+      expect(health.totalCards).toBe(1);
+    });
+
+    it('returns health for empty inventory', () => {
+      const health = getPortfolioHealth([]);
+      expect(health.totalCards).toBe(0);
+      expect(health.totalValue).toBe(0);
+      // With 0 cards, all actual allocations are 0% which means large drift from targets
+      expect(health.score).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('alert persistence', () => {
+    it('saves and retrieves alert history', () => {
+      const alerts = [
+        { id: 'test-1', isAcknowledged: false } as any,
+        { id: 'test-2', isAcknowledged: true } as any,
+      ];
+      saveAlertHistory(alerts);
+      const retrieved = getAlertHistory();
+      expect(retrieved).toHaveLength(2);
+      expect(retrieved[0].id).toBe('test-1');
+    });
+
+    it('returns empty array when localStorage is empty', () => {
+      expect(getAlertHistory()).toEqual([]);
+    });
+
+    it('acknowledges an alert by id', () => {
+      saveAlertHistory([
+        { id: 'alert-1', isAcknowledged: false } as any,
+        { id: 'alert-2', isAcknowledged: false } as any,
+      ]);
+      const updated = acknowledgeAlert('alert-1');
+      expect(updated.find(a => a.id === 'alert-1')!.isAcknowledged).toBe(true);
+      expect(updated.find(a => a.id === 'alert-2')!.isAcknowledged).toBe(false);
+    });
+
+    it('persistAlerts merges new and existing alerts', () => {
+      saveAlertHistory([
+        { id: 'old-1', isAcknowledged: true } as any,
+      ]);
+      persistAlerts([
+        { id: 'old-1', isAcknowledged: false } as any,
+        { id: 'new-1', isAcknowledged: false } as any,
+      ]);
+      const history = getAlertHistory();
+      // old-1 should retain acknowledged status
+      expect(history.find(a => a.id === 'old-1')!.isAcknowledged).toBe(true);
+      expect(history.find(a => a.id === 'new-1')!.isAcknowledged).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Cover rebalancingAlertService, anomalyDetectionService, auctionSniperService, priceChartService, and achievementService with comprehensive test suites including edge cases, persistence, and mathematical correctness.

https://claude.ai/code/session_01Cqy6SYqgQJ4kmgLbbcu48p