### PR TITLE
ci: fix and consolidate bundle size budgets

### DIFF
--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -52,9 +52,14 @@ jobs:
           TOTAL_RAW=0
           TOTAL_GZIP=0
 
-          # Budget thresholds (in bytes)
-          INDEX_BUDGET=$((200 * 1024))  # 200 KB gzip for index/entry
-          CHUNK_BUDGET=$((50 * 1024))   # 50 KB gzip for any other chunk
+          # Budget thresholds (in bytes, gzip). These mirror the chunking
+          # strategy enforced by scripts/ci-bundle-gate.cjs — the index entry,
+          # the shared lib-services chunk, and vendor chunks each get their
+          # own budget because they are intentional shared bundles.
+          INDEX_BUDGET=$((200 * 1024))         # 200 KB gzip
+          LIB_SERVICES_BUDGET=$((1200 * 1024)) # 1.2 MB gzip (intentional shared services chunk)
+          VENDOR_BUDGET=$((200 * 1024))        # 200 KB gzip for *-vendor chunks
+          CHUNK_BUDGET=$((50 * 1024))          # 50 KB gzip for any other chunk
 
           while IFS= read -r file; do
             filename=$(basename "$file")
@@ -74,25 +79,24 @@ jobs:
             raw_kb=$(echo "scale=1; $raw_size / 1024" | bc)
             gz_kb=$(echo "scale=1; $gz_size / 1024" | bc)
 
-            # Determine budget
-            if echo "$filename" | grep -qE '^index'; then
-              budget_kb=$(echo "scale=1; $INDEX_BUDGET / 1024" | bc)
-              budget_label="${budget_kb} KB"
-              if [ "$gz_size" -gt "$INDEX_BUDGET" ]; then
-                status="OVER BUDGET"
-                BUDGET_EXCEEDED=true
-              else
-                status="OK"
-              fi
+            # Determine budget based on chunk role
+            if echo "$filename" | grep -qE '^index[.-]'; then
+              budget=$INDEX_BUDGET
+            elif echo "$filename" | grep -qE '^lib-services[.-]'; then
+              budget=$LIB_SERVICES_BUDGET
+            elif echo "$filename" | grep -qE '\-vendor[.-]'; then
+              budget=$VENDOR_BUDGET
             else
-              budget_kb=$(echo "scale=1; $CHUNK_BUDGET / 1024" | bc)
-              budget_label="${budget_kb} KB"
-              if [ "$gz_size" -gt "$CHUNK_BUDGET" ]; then
-                status="OVER BUDGET"
-                BUDGET_EXCEEDED=true
-              else
-                status="OK"
-              fi
+              budget=$CHUNK_BUDGET
+            fi
+
+            budget_kb=$(echo "scale=1; $budget / 1024" | bc)
+            budget_label="${budget_kb} KB"
+            if [ "$gz_size" -gt "$budget" ]; then
+              status="OVER BUDGET"
+              BUDGET_EXCEEDED=true
+            else
+              status="OK"
             fi
 
             echo "| \`${filename}\` | ${raw_kb} KB | ${gz_kb} KB | ${budget_label} | ${status} |" >> bundle-report.md
@@ -146,9 +150,11 @@ jobs:
             echo "" >> bundle-report.md
             echo "One or more chunks exceed the size budget. Please optimize before merging." >> bundle-report.md
             echo "" >> bundle-report.md
-            echo "**Budgets:**" >> bundle-report.md
-            echo "- \`index*.js\`: < 200 KB gzip" >> bundle-report.md
-            echo "- Any other chunk: < 50 KB gzip" >> bundle-report.md
+            echo "**Budgets (gzip):**" >> bundle-report.md
+            echo "- \`index*.js\`: < 200 KB" >> bundle-report.md
+            echo "- \`lib-services*.js\`: < 1200 KB (intentional shared services chunk)" >> bundle-report.md
+            echo "- \`*-vendor*.js\`: < 200 KB" >> bundle-report.md
+            echo "- Any other chunk: < 50 KB" >> bundle-report.md
             echo "BUDGET_EXCEEDED=true" >> "$GITHUB_ENV"
           else
             echo "### Result: ALL BUDGETS MET" >> bundle-report.md

--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -28,158 +28,10 @@ jobs:
       - name: Build production bundle
         run: npm run build
 
-      - name: Measure bundle sizes
-        id: bundle
-        run: |
-          # Create gzipped versions of all JS/CSS assets
-          find dist/assets -type f \( -name '*.js' -o -name '*.css' \) | while read -r file; do
-            gzip -k -9 "$file"
-          done
-
-          echo "## Bundle Size Analysis" > bundle-report.md
-          echo "" >> bundle-report.md
-          echo "**PR:** #${{ github.event.pull_request.number }}" >> bundle-report.md
-          echo "**Commit:** \`${{ github.sha }}\`" >> bundle-report.md
-          echo "" >> bundle-report.md
-
-          # ── Per-chunk breakdown ──
-          echo "### Chunk Breakdown" >> bundle-report.md
-          echo "" >> bundle-report.md
-          echo "| Chunk | Raw Size | Gzip Size | Budget | Status |" >> bundle-report.md
-          echo "|-------|----------|-----------|--------|--------|" >> bundle-report.md
-
-          BUDGET_EXCEEDED=false
-          TOTAL_RAW=0
-          TOTAL_GZIP=0
-
-          # Budget thresholds (in bytes, gzip). These mirror the chunking
-          # strategy enforced by scripts/ci-bundle-gate.cjs — the index entry,
-          # the shared lib-services chunk, and vendor chunks each get their
-          # own budget because they are intentional shared bundles.
-          INDEX_BUDGET=$((200 * 1024))         # 200 KB gzip
-          LIB_SERVICES_BUDGET=$((1200 * 1024)) # 1.2 MB gzip (intentional shared services chunk)
-          VENDOR_BUDGET=$((200 * 1024))        # 200 KB gzip for *-vendor chunks
-          CHUNK_BUDGET=$((50 * 1024))          # 50 KB gzip for any other chunk
-
-          while IFS= read -r file; do
-            filename=$(basename "$file")
-            raw_size=$(stat --format=%s "$file" 2>/dev/null || stat -f%z "$file" 2>/dev/null)
-            gz_file="${file}.gz"
-
-            if [ -f "$gz_file" ]; then
-              gz_size=$(stat --format=%s "$gz_file" 2>/dev/null || stat -f%z "$gz_file" 2>/dev/null)
-            else
-              gz_size=$raw_size
-            fi
-
-            TOTAL_RAW=$((TOTAL_RAW + raw_size))
-            TOTAL_GZIP=$((TOTAL_GZIP + gz_size))
-
-            # Human-readable sizes
-            raw_kb=$(echo "scale=1; $raw_size / 1024" | bc)
-            gz_kb=$(echo "scale=1; $gz_size / 1024" | bc)
-
-            # Determine budget based on chunk role
-            if echo "$filename" | grep -qE '^index[.-]'; then
-              budget=$INDEX_BUDGET
-            elif echo "$filename" | grep -qE '^lib-services[.-]'; then
-              budget=$LIB_SERVICES_BUDGET
-            elif echo "$filename" | grep -qE '\-vendor[.-]'; then
-              budget=$VENDOR_BUDGET
-            else
-              budget=$CHUNK_BUDGET
-            fi
-
-            budget_kb=$(echo "scale=1; $budget / 1024" | bc)
-            budget_label="${budget_kb} KB"
-            if [ "$gz_size" -gt "$budget" ]; then
-              status="OVER BUDGET"
-              BUDGET_EXCEEDED=true
-            else
-              status="OK"
-            fi
-
-            echo "| \`${filename}\` | ${raw_kb} KB | ${gz_kb} KB | ${budget_label} | ${status} |" >> bundle-report.md
-          done < <(find dist/assets -type f -name '*.js' | sort)
-
-          echo "" >> bundle-report.md
-
-          # CSS files
-          echo "### CSS Assets" >> bundle-report.md
-          echo "" >> bundle-report.md
-          echo "| File | Raw Size | Gzip Size |" >> bundle-report.md
-          echo "|------|----------|-----------|" >> bundle-report.md
-
-          while IFS= read -r file; do
-            filename=$(basename "$file")
-            raw_size=$(stat --format=%s "$file" 2>/dev/null || stat -f%z "$file" 2>/dev/null)
-            gz_file="${file}.gz"
-            if [ -f "$gz_file" ]; then
-              gz_size=$(stat --format=%s "$gz_file" 2>/dev/null || stat -f%z "$gz_file" 2>/dev/null)
-            else
-              gz_size=$raw_size
-            fi
-            raw_kb=$(echo "scale=1; $raw_size / 1024" | bc)
-            gz_kb=$(echo "scale=1; $gz_size / 1024" | bc)
-            TOTAL_RAW=$((TOTAL_RAW + raw_size))
-            TOTAL_GZIP=$((TOTAL_GZIP + gz_size))
-            echo "| \`${filename}\` | ${raw_kb} KB | ${gz_kb} KB |" >> bundle-report.md
-          done < <(find dist/assets -type f -name '*.css' | sort)
-
-          echo "" >> bundle-report.md
-
-          # ── Totals ──
-          TOTAL_RAW_KB=$(echo "scale=1; $TOTAL_RAW / 1024" | bc)
-          TOTAL_GZIP_KB=$(echo "scale=1; $TOTAL_GZIP / 1024" | bc)
-          TOTAL_RAW_MB=$(echo "scale=2; $TOTAL_RAW / 1048576" | bc)
-          TOTAL_GZIP_MB=$(echo "scale=2; $TOTAL_GZIP / 1048576" | bc)
-
-          echo "### Totals" >> bundle-report.md
-          echo "" >> bundle-report.md
-          echo "| Metric | Value |" >> bundle-report.md
-          echo "|--------|-------|" >> bundle-report.md
-          echo "| Total raw | ${TOTAL_RAW_KB} KB (${TOTAL_RAW_MB} MB) |" >> bundle-report.md
-          echo "| Total gzip | ${TOTAL_GZIP_KB} KB (${TOTAL_GZIP_MB} MB) |" >> bundle-report.md
-          echo "| JS chunks | $(find dist/assets -name '*.js' | wc -l) |" >> bundle-report.md
-          echo "| CSS files | $(find dist/assets -name '*.css' | wc -l) |" >> bundle-report.md
-          echo "" >> bundle-report.md
-
-          # ── Budget verdict ──
-          if [ "$BUDGET_EXCEEDED" = true ]; then
-            echo "### Result: BUDGET EXCEEDED" >> bundle-report.md
-            echo "" >> bundle-report.md
-            echo "One or more chunks exceed the size budget. Please optimize before merging." >> bundle-report.md
-            echo "" >> bundle-report.md
-            echo "**Budgets (gzip):**" >> bundle-report.md
-            echo "- \`index*.js\`: < 200 KB" >> bundle-report.md
-            echo "- \`lib-services*.js\`: < 1200 KB (intentional shared services chunk)" >> bundle-report.md
-            echo "- \`*-vendor*.js\`: < 200 KB" >> bundle-report.md
-            echo "- Any other chunk: < 50 KB" >> bundle-report.md
-            echo "BUDGET_EXCEEDED=true" >> "$GITHUB_ENV"
-          else
-            echo "### Result: ALL BUDGETS MET" >> bundle-report.md
-            echo "" >> bundle-report.md
-            echo "All chunks are within the performance budget." >> bundle-report.md
-            echo "BUDGET_EXCEEDED=false" >> "$GITHUB_ENV"
-          fi
-
-          # Store total for trend tracking
-          echo "TOTAL_GZIP_KB=${TOTAL_GZIP_KB}" >> "$GITHUB_ENV"
-
-      - name: Store bundle size for trend tracking
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const totalGzipKb = process.env.TOTAL_GZIP_KB;
-            const sha = context.sha.substring(0, 7);
-            const date = new Date().toISOString().split('T')[0];
-
-            // Add trend data as a comment tag for historical tracking
-            const trendLine = `<!-- bundle-trend: ${date} ${sha} ${totalGzipKb}KB -->`;
-
-            core.info(`Bundle trend data: ${trendLine}`);
-            core.exportVariable('TREND_DATA', trendLine);
+      - name: Check bundle size budget (gzip)
+        id: gate
+        continue-on-error: true
+        run: node scripts/ci-bundle-gate.cjs --mode gzip --report bundle-report.md
 
       - name: Comment on PR
         uses: actions/github-script@v7
@@ -187,19 +39,16 @@ jobs:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('bundle-report.md', 'utf8');
-            const trendData = process.env.TREND_DATA || '';
+            const sha = context.sha.substring(0, 7);
+            const body = `${report}\n\n*Built from ${sha} — pull_request #${context.issue.number}*`;
 
-            const body = report + '\n\n' + trendData;
-
-            // Find existing bot comment
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-
             const botComment = comments.find(
-              (c) => c.user?.type === 'Bot' && c.body?.includes('Bundle Size Analysis')
+              (c) => c.user?.type === 'Bot' && c.body?.includes('Bundle Size Analysis'),
             );
 
             if (botComment) {
@@ -219,6 +68,7 @@ jobs:
             }
 
       - name: Upload bundle report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: bundle-report
@@ -226,7 +76,7 @@ jobs:
           retention-days: 30
 
       - name: Fail if budget exceeded
-        if: env.BUDGET_EXCEEDED == 'true'
+        if: steps.gate.outcome == 'failure'
         run: |
           echo "::error::Bundle size budget exceeded! See the PR comment for details."
           exit 1

--- a/scripts/ci-bundle-gate.cjs
+++ b/scripts/ci-bundle-gate.cjs
@@ -1,23 +1,67 @@
 /**
- * CI bundle size gate — checks dist/assets against size budgets.
- * Run after `vite build`; exits 1 if any chunk exceeds its budget.
+ * CI bundle size gate — single source of truth for chunk role detection
+ * and budgets. Used by:
+ *   - npm run ci:bundle              (raw budgets, Build & Test job)
+ *   - performance-budget.yml workflow (gzip budgets, PR comment)
  *
- * Budgets (raw, uncompressed):
- *   index chunk  : 4 MB
- *   lib services : 4.25 MB (intentional shared service chunk)
- *   any other JS : 1.5 MB
- *   total JS     : 12 MB
+ * Usage:
+ *   node scripts/ci-bundle-gate.cjs [--mode raw|gzip] [--report <path>]
+ *
+ * Exits 1 if any chunk exceeds its budget for the chosen mode. With
+ * --report, writes a markdown report regardless of exit code so a PR
+ * comment can still be posted on failure.
  */
 'use strict';
 
 const fs = require('fs');
 const path = require('path');
+const zlib = require('zlib');
 
-const INDEX_BUDGET_BYTES = 4 * 1024 * 1024; // 4 MB
-const LIB_SERVICES_BUDGET_BYTES = 4.25 * 1024 * 1024; // 4.25 MB
-const CHUNK_BUDGET_BYTES = 1.5 * 1024 * 1024; // 1.5 MB
-const TOTAL_BUDGET_BYTES = 12 * 1024 * 1024; // 12 MB
+const BUDGETS = {
+  raw: {
+    index: 4 * 1024 * 1024,
+    'lib-services': 4.25 * 1024 * 1024,
+    vendor: 2 * 1024 * 1024,
+    chunk: 1.5 * 1024 * 1024,
+    total: 12 * 1024 * 1024,
+  },
+  gzip: {
+    index: 200 * 1024,
+    'lib-services': 1200 * 1024,
+    vendor: 200 * 1024,
+    chunk: 50 * 1024,
+    total: 3 * 1024 * 1024,
+  },
+};
 
+function getChunkRole(filename) {
+  if (/^index[.-]/.test(filename)) return 'index';
+  if (/^lib-services[.-]/.test(filename)) return 'lib-services';
+  if (/-vendor[.-]/.test(filename)) return 'vendor';
+  return 'chunk';
+}
+
+function parseArgs(argv) {
+  const out = { mode: 'raw', report: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--mode') out.mode = argv[++i];
+    else if (a.startsWith('--mode=')) out.mode = a.slice('--mode='.length);
+    else if (a === '--report') out.report = argv[++i];
+    else if (a.startsWith('--report=')) out.report = a.slice('--report='.length);
+  }
+  if (out.mode !== 'raw' && out.mode !== 'gzip') {
+    console.error(`Invalid --mode: ${out.mode}. Use 'raw' or 'gzip'.`);
+    process.exit(2);
+  }
+  return out;
+}
+
+function logicalChunkName(name) {
+  return name.replace(/-[A-Za-z0-9_-]{8,}\.js$/, '.js');
+}
+
+const { mode, report: reportPath } = parseArgs(process.argv.slice(2));
 const distAssets = path.join(process.cwd(), 'dist', 'assets');
 
 if (!fs.existsSync(distAssets)) {
@@ -25,70 +69,121 @@ if (!fs.existsSync(distAssets)) {
   process.exit(1);
 }
 
-const jsFiles = fs.readdirSync(distAssets)
-  .filter(f => f.endsWith('.js'))
-  .map(f => {
-    const stat = fs.statSync(path.join(distAssets, f));
-    return { name: f, size: stat.size, mtimeMs: stat.mtimeMs };
+const allJs = fs
+  .readdirSync(distAssets)
+  .filter((f) => f.endsWith('.js'))
+  .map((f) => {
+    const full = path.join(distAssets, f);
+    const stat = fs.statSync(full);
+    return { name: f, path: full, rawSize: stat.size, mtimeMs: stat.mtimeMs };
   });
 
-if (jsFiles.length === 0) {
+if (allJs.length === 0) {
   console.error('❌  No JS files found in dist/assets.');
   process.exit(1);
 }
 
-function logicalChunkName(name) {
-  return name.replace(/-[A-Za-z0-9_-]{8,}\.js$/, '.js');
-}
-
-const latestByLogicalName = new Map();
-for (const file of jsFiles) {
+const latestByLogical = new Map();
+for (const file of allJs) {
   const key = logicalChunkName(file.name);
-  const existing = latestByLogicalName.get(key);
+  const existing = latestByLogical.get(key);
   if (!existing || file.mtimeMs > existing.mtimeMs) {
-    latestByLogicalName.set(key, file);
+    latestByLogical.set(key, file);
+  }
+}
+const files = Array.from(latestByLogical.values());
+const staleCount = allJs.length - files.length;
+
+const wantsGzip = mode === 'gzip' || reportPath !== null;
+if (wantsGzip) {
+  for (const f of files) {
+    f.gzipSize = zlib.gzipSync(fs.readFileSync(f.path), { level: 9 }).length;
   }
 }
 
-const budgetedFiles = Array.from(latestByLogicalName.values()).sort((a, b) => b.size - a.size);
-const staleCount = jsFiles.length - budgetedFiles.length;
-const totalBytes = budgetedFiles.reduce((s, f) => s + f.size, 0);
-let exceeded = false;
+const budgets = BUDGETS[mode];
+const sizeKey = mode === 'gzip' ? 'gzipSize' : 'rawSize';
+files.sort((a, b) => b[sizeKey] - a[sizeKey]);
 
 const kb = (b) => (b / 1024).toFixed(1);
 const mb = (b) => (b / 1024 / 1024).toFixed(2);
 
+let exceeded = false;
+const rows = [];
+
 console.log('\nBundle Size Gate');
-console.log('='.repeat(72));
+console.log('='.repeat(82));
+console.log(`Mode: ${mode}`);
 if (staleCount > 0) {
   console.log(`Ignoring ${staleCount} stale hashed asset${staleCount === 1 ? '' : 's'} from prior builds.`);
 }
-console.log(`${'File'.padEnd(48)} ${'Size'.padStart(9)} ${'Budget'.padStart(9)} Status`);
-console.log(`${'-'.repeat(48)} ${'-'.repeat(9)} ${'-'.repeat(9)} ------`);
+console.log(`${'File'.padEnd(50)} ${'Size'.padStart(10)} ${'Budget'.padStart(10)} Status`);
+console.log(`${'-'.repeat(50)} ${'-'.repeat(10)} ${'-'.repeat(10)} ------`);
 
-for (const { name, size } of budgetedFiles) {
-  const isIndex = /^index[.-]/.test(name);
-  const isLibServices = /^lib-services[.-]/.test(name);
-  const budget = isIndex
-    ? INDEX_BUDGET_BYTES
-    : isLibServices
-      ? LIB_SERVICES_BUDGET_BYTES
-      : CHUNK_BUDGET_BYTES;
+for (const f of files) {
+  const role = getChunkRole(f.name);
+  const budget = budgets[role];
+  const size = f[sizeKey];
   const ok = size <= budget;
   if (!ok) exceeded = true;
-  const label = ok ? 'OK' : 'OVER BUDGET ⚠️';
-  console.log(`${name.slice(0, 48).padEnd(48)} ${(kb(size) + ' KB').padStart(9)} ${(kb(budget) + ' KB').padStart(9)} ${label}`);
+  console.log(
+    `${f.name.slice(0, 50).padEnd(50)} ${(kb(size) + ' KB').padStart(10)} ${(kb(budget) + ' KB').padStart(10)} ${ok ? 'OK' : 'OVER ⚠️'}`,
+  );
+  rows.push({ name: f.name, role, rawSize: f.rawSize, gzipSize: f.gzipSize, budget, ok });
 }
 
-console.log('='.repeat(72));
-const totalOk = totalBytes <= TOTAL_BUDGET_BYTES;
+const totalRaw = files.reduce((s, f) => s + f.rawSize, 0);
+const totalGzip = wantsGzip ? files.reduce((s, f) => s + f.gzipSize, 0) : 0;
+const totalSize = mode === 'gzip' ? totalGzip : totalRaw;
+const totalBudget = budgets.total;
+const totalOk = totalSize <= totalBudget;
 if (!totalOk) exceeded = true;
-console.log(`Total: ${mb(totalBytes)} MB  (budget: ${mb(TOTAL_BUDGET_BYTES)} MB)  ${totalOk ? '✅' : '❌ OVER BUDGET'}`);
-console.log();
+
+console.log('='.repeat(82));
+console.log(`Total: ${mb(totalSize)} MB  (budget: ${mb(totalBudget)} MB)  ${totalOk ? '✅' : '❌ OVER'}`);
+
+if (reportPath) {
+  const lines = [];
+  lines.push('## Bundle Size Analysis');
+  lines.push('');
+  lines.push(`**Mode:** ${mode}`);
+  lines.push('');
+  lines.push('### Chunk Breakdown');
+  lines.push('');
+  lines.push(`| Chunk | Role | Raw | Gzip | Budget (${mode}) | Status |`);
+  lines.push('|-------|------|-----|------|--------|--------|');
+  for (const r of rows) {
+    const status = r.ok ? 'OK' : 'OVER BUDGET';
+    lines.push(
+      `| \`${r.name}\` | ${r.role} | ${kb(r.rawSize)} KB | ${kb(r.gzipSize)} KB | ${kb(r.budget)} KB | ${status} |`,
+    );
+  }
+  lines.push('');
+  lines.push('### Totals');
+  lines.push('');
+  lines.push('| Metric | Value |');
+  lines.push('|--------|-------|');
+  lines.push(`| Total raw | ${kb(totalRaw)} KB (${mb(totalRaw)} MB) |`);
+  lines.push(`| Total gzip | ${kb(totalGzip)} KB (${mb(totalGzip)} MB) |`);
+  lines.push(`| JS chunks | ${rows.length} |`);
+  lines.push(`| Budget (total ${mode}) | ${mb(totalBudget)} MB |`);
+  lines.push('');
+  lines.push(`### Budgets (${mode})`);
+  lines.push('');
+  lines.push('| Role | Budget |');
+  lines.push('|------|--------|');
+  for (const [role, b] of Object.entries(budgets)) {
+    if (role === 'total') continue;
+    lines.push(`| \`${role}\` | ${kb(b)} KB |`);
+  }
+  lines.push('');
+  lines.push(exceeded ? '### Result: BUDGET EXCEEDED' : '### Result: ALL BUDGETS MET');
+  lines.push('');
+  fs.writeFileSync(reportPath, lines.join('\n') + '\n');
+}
 
 if (exceeded) {
-  console.error('❌  Bundle budget exceeded. Check chunks above and apply code splitting or tree-shaking.');
+  console.error('\n❌  Bundle budget exceeded.');
   process.exit(1);
 }
-
-console.log('✅  All bundle budgets met.');
+console.log('\n✅  All bundle budgets met.');


### PR DESCRIPTION
## Summary
The `Check Bundle Size Budget` job in `performance-budget.yml` was failing on every open PR (#55–#58) because it applied a flat 50 KB gzip budget to every non-`index` chunk — which the intentional shared `lib-services` (~1.08 MB gzip) and `*-vendor` (~71–118 KB gzip) chunks always blow. The source-of-truth gate in `scripts/ci-bundle-gate.cjs` (run inside `Build & Test`) had been taught about those chunk roles in a prior fix, but the workflow's inline budget logic was never updated. Same trap waiting to happen again next time we add a new shared chunk.

Two commits:

1. **Align workflow budgets** (`112a5cc`) — quickest unblock: gives the workflow per-role gzip budgets (200 KB / 1.2 MB / 200 KB / 50 KB) matching the chunking strategy. PR CI now goes green.
2. **Consolidate to one source of truth** (`ca59c34`) — drift-proofs it: extends `scripts/ci-bundle-gate.cjs` with `--mode raw|gzip` and `--report <path>`, teaches it the four chunk roles (`index`, `lib-services`, `vendor`, `chunk`), and rewrites the workflow to just invoke the script and post the markdown report. The workflow no longer encodes budget values inline, so the script and workflow cannot diverge.

## Test plan
- [x] `node scripts/ci-bundle-gate.cjs` (raw mode) — passes locally (11.09 MB / 12 MB budget).
- [x] `node scripts/ci-bundle-gate.cjs --mode gzip --report /tmp/r.md` — passes locally (2.68 MB / 3 MB total, all chunks under their per-role budget); report renders cleanly.
- [x] `npm run ci:bundle` (the `Build & Test` invocation) — unchanged behavior, still passes.
- [x] `npm run format:check` and `npm run lint` — clean.
- [x] `Check Bundle Size Budget` already green on commit `112a5cc`. Awaiting CI on the consolidation commit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix and consolidate bundle size budgets in CI using gzip mode and role-based limits
> - Replaces the inline bash bundle measurement and GitHub Script trend-tracking steps in [performance-budget.yml](.github/workflows/performance-budget.yml) with a single gate step invoking `node scripts/ci-bundle-gate.cjs --mode gzip --report bundle-report.md`.
> - Updates [ci-bundle-gate.cjs](scripts/ci-bundle-gate.cjs) to support raw and gzip modes, replacing individual byte constants with a `BUDGETS` map covering per-role (`index`, `lib-services`, `vendor`, `chunk`) and total limits.
> - Adds a `getChunkRole` classifier and `parseArgs` helper; invalid `--mode` values now exit with code 2.
> - Generates an optional Markdown report summarizing chunks, totals, and budgets when `--report` is provided.
> - Behavioral Change: the workflow now fails based on the gate step's outcome rather than a `BUDGET_EXCEEDED` env var, and artifact upload runs unconditionally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca59c34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->