### PR TITLE
World-class pass 1: bundle split, a11y gate fix, Labs enforcement, adapter truth

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -2,3 +2,5 @@
 # so the "Enter Demo Mode" button appears on the login page.
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
+# E2E specs cover Labs routes (war room, autonomous acquisition, etc.)
+VITE_FF_ENABLE_BETA_SURFACES=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Build
+        # Labs flag on so downstream route/a11y/visual smoke jobs exercise the
+        # full surface. Production (Vercel) builds without the flag and hides
+        # Labs routes per docs/MVP_LAUNCH_SCOPE.md.
+        env:
+          VITE_FF_ENABLE_BETA_SURFACES: '1'
         run: npm run build
 
       - name: Bundle size gate

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Thumbs.db
 # Claude Code
 .claude/
 .env*.local
+
+# Lighthouse CI local run output
+.lighthouseci/

--- a/App.tsx
+++ b/App.tsx
@@ -29,6 +29,12 @@ import DocumentTitleSync from './components/DocumentTitleSync.tsx';
 import CommandPalette from './components/CommandPalette.tsx';
 import { validateEnv } from './lib/utils/env';
 import { initDAL } from './lib/dal';
+import { isBetaSurfacesEnabled } from './lib/productionLaunch';
+
+// Labs routes (everything outside the curated product surface) only mount when
+// the beta-surfaces flag is on. Dev builds keep them on for convenience; see
+// docs/MVP_LAUNCH_SCOPE.md for the launch boundary.
+const labsEnabled = isBetaSurfacesEnabled() || import.meta.env.DEV;
 
 // Validate environment on startup
 validateEnv();
@@ -564,6 +570,12 @@ const AppLayout: React.FC<{ isSidebarOpen: boolean, setIsSidebarOpen: React.Disp
                 <Route path="/private-deal-room-agent" element={<PrivateDealRoomAgent />} />
                 <Route path="/catalyst-market" element={<CatalystMarket />} />
                 <Route path="/collection-narrative" element={<CollectionNarrative />} />
+                <Route path="/frontier-lab" element={<FrontierLab />} />
+                {/* Labs surface — the long tail ships only when VITE_FF_ENABLE_BETA_SURFACES
+                    is set (see lib/productionLaunch.ts and docs/MVP_LAUNCH_SCOPE.md).
+                    Production hides these routes; unknown paths fall through to the
+                    catch-all below. */}
+                {labsEnabled && (<>
                 <Route path="/portfolio-copilot" element={<PortfolioCopilot />} />
                 <Route path="/marketplace-aggregator" element={<MarketplaceAggregator />} />
                 <Route path="/subscription-box" element={<SubscriptionBox />} />
@@ -761,7 +773,6 @@ const AppLayout: React.FC<{ isSidebarOpen: boolean, setIsSidebarOpen: React.Disp
                 <Route path="/rebalancer" element={<Rebalancer />} />
                 {/* Showcase & Labs — Previously Unrouted */}
                 <Route path="/ar-showcase" element={<ARShowcase />} />
-                <Route path="/frontier-lab" element={<FrontierLab />} />
                 <Route path="/live-impact" element={<LiveImpact />} />
                 <Route path="/inventory" element={<Inventory />} />
                 {/* v6.1: Industry-Absent Innovation — Round 2 */}
@@ -881,6 +892,7 @@ const AppLayout: React.FC<{ isSidebarOpen: boolean, setIsSidebarOpen: React.Disp
                 <Route path="/product-announcement-radar" element={<ProductAnnouncementRadar />} />
                 <Route path="/collector-succession-protocol" element={<CollectorSuccessionProtocol />} />
                 <Route path="/cross-hobby-arbitrage-bridge" element={<CrossHobbyArbitrageBridge />} />
+                </>)}
                 {/* Interactive Demo Flow */}
                 <Route path="/demo-flow" element={<DemoFlowPage />} />
                 <Route path="*" element={<Navigate to="/" replace />} />

--- a/docs/LAUNCH_OPS_PUNCH_LIST.md
+++ b/docs/LAUNCH_OPS_PUNCH_LIST.md
@@ -39,8 +39,8 @@ Point any uptime service (UptimeRobot, Checkly, Vercel checks) at `GET /api/heal
 
 Server-side env (Vercel), never `VITE_*`:
 
-- eBay: `EBAY_CLIENT_ID` / `EBAY_CLIENT_SECRET`, then set `VITE_FF_USE_REAL_EBAY=true`
-- PSA: `PSA_API_KEY` (consumed by `api/grading/psa/cert.ts`), then `VITE_FF_USE_REAL_PSA=true`
+- eBay: `EBAY_CLIENT_ID` / `EBAY_CLIENT_SECRET`, then set `VITE_FF_REAL_EBAY=true`
+- PSA: `PSA_API_KEY` (consumed by `api/grading/psa/cert.ts`), then `VITE_FF_REAL_PSA=true`
 
 The adapters now tag every response `source: 'live' | 'mock'` with a `degradedReason` on live failures — UI surfaces can trust the label.
 

--- a/docs/LAUNCH_OPS_PUNCH_LIST.md
+++ b/docs/LAUNCH_OPS_PUNCH_LIST.md
@@ -1,0 +1,63 @@
+# Launch ops punch list — owner actions
+
+Engineering work for the world-class pass is in the repo (Labs route gating, domain-split bundles, Lighthouse a11y fix, honest adapter sourcing). The items below need credentials or accounts only the project owner holds. Each is small; together they complete `docs/PRODUCTION_ROLLOUT_PHASES.md`.
+
+## 1. RLS verification with real users (Phase A2)
+
+Create one test user per tier (free/basic/pro/alpha) in the Supabase dashboard, then run:
+
+```bash
+SUPABASE_DB_URL=postgres://... npm run verify:rls   # see scripts/run-rls-checks.mjs
+```
+
+Pass = every cross-tenant SELECT/UPDATE returns 0 rows. Record the run date here.
+
+- [ ] Run completed on: \_\_\_\_
+
+## 2. Error telemetry in production (Phase D2)
+
+Create a (free-tier) Sentry project and set in Vercel → Project → Environment Variables:
+
+- `VITE_SENTRY_DSN=<dsn>`
+- `VITE_REQUIRE_TELEMETRY=true` (makes future builds fail loudly if telemetry is ever dropped)
+
+- [ ] DSN set and a test error visible in Sentry
+
+## 3. Deployed E2E (Phase E2)
+
+Set GitHub repo secret `PLAYWRIGHT_DEPLOYMENT_URL=https://<prod>.vercel.app` and repo variable `ENABLE_DEPLOYED_E2E=true`. This activates `.github/workflows/deployed-e2e.yml` (runs after each merge to main + daily).
+
+- [ ] Secret + variable set, first green run linked: \_\_\_\_
+
+## 4. Uptime monitoring (Phase D1)
+
+Point any uptime service (UptimeRobot, Checkly, Vercel checks) at `GET /api/health` on the production URL. Alert at 2 consecutive failures.
+
+- [ ] Monitor live
+
+## 5. Real-data API keys (when ready to leave mock mode)
+
+Server-side env (Vercel), never `VITE_*`:
+
+- eBay: `EBAY_CLIENT_ID` / `EBAY_CLIENT_SECRET`, then set `VITE_FF_USE_REAL_EBAY=true`
+- PSA: `PSA_API_KEY` (consumed by `api/grading/psa/cert.ts`), then `VITE_FF_USE_REAL_PSA=true`
+
+The adapters now tag every response `source: 'live' | 'mock'` with a `degradedReason` on live failures — UI surfaces can trust the label.
+
+- [ ] eBay keys set · [ ] PSA key set
+
+## 6. Stripe lifecycle smoke (money path)
+
+In Stripe test mode against the production deployment: subscribe → upgrade → downgrade → cancel → failed-payment (use card `4000 0000 0000 0341`). Verify webhook events land (Stripe dashboard → webhook deliveries, all 2xx) and the user's tier updates each step.
+
+- [ ] All five transitions verified
+
+## 7. GDPR endpoints (just landed)
+
+While signed in on production: call `/api/me/export` (expect a JSON download of your data) and on a throwaway account `/api/me/delete` (expect account + rows gone, sign-in revoked).
+
+- [ ] Export verified · [ ] Delete verified
+
+## Labs surface reminder
+
+Production hides the long-tail routes unless `VITE_FF_ENABLE_BETA_SURFACES=1` is set in the Vercel env. Leave it **unset** for GA per `docs/MVP_LAUNCH_SCOPE.md`; set it on preview deployments if you want the full surface for demos.

--- a/lib/integrations/ebayAdapter.ts
+++ b/lib/integrations/ebayAdapter.ts
@@ -31,6 +31,10 @@ export interface EbayMarketData {
     isSold: boolean;
   }>;
   lastUpdated: string;
+  /** Where the numbers came from. Mock data must never be presented as live comps. */
+  source: 'live' | 'mock';
+  /** Set when the live API was requested but failed and mock data was substituted. */
+  degradedReason?: string;
 }
 
 export interface EbaySearchParams {
@@ -45,9 +49,25 @@ export interface EbaySearchParams {
   limit?: number;
 }
 
+/**
+ * Price trend from sale history: percent change between the average of the
+ * older half and the newer half of sales, sorted by date. Returns 0 when
+ * there are fewer than 4 sales (not enough signal to split).
+ */
+export function computeTrendPercent(sales: Array<{ price: number; date: string }>): number {
+  if (sales.length < 4) return 0;
+  const sorted = [...sales].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  const mid = Math.floor(sorted.length / 2);
+  const avg = (xs: Array<{ price: number }>) => xs.reduce((s, x) => s + x.price, 0) / xs.length;
+  const older = avg(sorted.slice(0, mid));
+  const newer = avg(sorted.slice(mid));
+  if (older <= 0) return 0;
+  return Math.round(((newer - older) / older) * 100 * 100) / 100;
+}
+
 // ─── Mock Data ────────────────────────────────────────────────────
 
-function generateMockMarketData(params: EbaySearchParams): EbayMarketData {
+function generateMockMarketData(params: EbaySearchParams, degradedReason?: string): EbayMarketData {
   // Generate realistic mock data based on input
   const hash = (params.playerName + (params.cardYear || '')).split('').reduce((a, c) => a + c.charCodeAt(0), 0);
   const basePrice = 10 + (hash % 500);
@@ -74,6 +94,8 @@ function generateMockMarketData(params: EbaySearchParams): EbayMarketData {
     trendPercent: Math.round((Math.random() - 0.4) * 20 * 100) / 100,
     recentSales: sales,
     lastUpdated: new Date().toISOString(),
+    source: 'mock',
+    ...(degradedReason ? { degradedReason } : {}),
   };
 }
 
@@ -96,23 +118,28 @@ export const ebayAdapter = {
             daysBack: params.daysBack,
           });
 
+          const recentSales = result.recentSales.map(s => ({
+            ...s,
+            isSold: true,
+          }));
           return {
             averagePrice: result.averagePrice,
             medianPrice: result.medianPrice,
             lowPrice: result.priceRange.min,
             highPrice: result.priceRange.max,
             totalListings: result.totalListings,
-            soldListings: result.recentSales.length,
-            trendPercent: 0, // TODO: calculate from historical data
-            recentSales: result.recentSales.map(s => ({
-              ...s,
-              isSold: true,
-            })),
+            soldListings: recentSales.length,
+            trendPercent: computeTrendPercent(recentSales),
+            recentSales,
             lastUpdated: new Date().toISOString(),
+            source: 'live' as const,
           };
         } catch (err) {
           logger.warn('[eBay] Real API failed, falling back to mock', err);
-          return generateMockMarketData(params);
+          return generateMockMarketData(
+            params,
+            `Live eBay request failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
       }
 

--- a/lib/integrations/psaAdapter.ts
+++ b/lib/integrations/psaAdapter.ts
@@ -13,7 +13,15 @@ import { logger } from '../logger';
 
 export interface CertLookupResult {
   certNumber: string;
+  /**
+   * True only when PSA's records confirm the cert. With `source: 'mock'` this
+   * is simulated and must never be shown as real PSA verification.
+   */
   verified: boolean;
+  /** Where the result came from. Mock results must be labeled in the UI. */
+  source: 'live' | 'mock';
+  /** Set when the live API was requested but failed and mock data was substituted. */
+  degradedReason?: string;
   year?: string;
   brand?: string;
   set?: string;
@@ -42,11 +50,15 @@ export interface PopReportResult {
   grades: PopEntry[];
   totalGraded: number;
   lastUpdated: string;
+  /** Where the report came from. Mock results must be labeled in the UI. */
+  source: 'live' | 'mock';
+  /** Set when the live API was requested but failed and mock data was substituted. */
+  degradedReason?: string;
 }
 
 // ─── Mock Data ────────────────────────────────────────────────────
 
-function mockCertLookup(certNumber: string): CertLookupResult {
+function mockCertLookup(certNumber: string, degradedReason?: string): CertLookupResult {
   // Generate deterministic mock based on cert number
   const hash = certNumber.split('').reduce((a, c) => a + c.charCodeAt(0), 0);
   const grades = ['10', '9.5', '9', '8.5', '8', '7.5', '7', '6'];
@@ -65,10 +77,12 @@ function mockCertLookup(certNumber: string): CertLookupResult {
     grade: grades[hash % grades.length],
     labelType: hash % 3 === 0 ? 'Gem Mint' : 'Standard',
     lookupDate: new Date().toISOString(),
+    source: 'mock',
+    ...(degradedReason ? { degradedReason } : {}),
   };
 }
 
-function mockPopReport(player: string, year: string, set: string): PopReportResult {
+function mockPopReport(player: string, year: string, set: string, degradedReason?: string): PopReportResult {
   return {
     year,
     brand: 'Topps',
@@ -89,6 +103,8 @@ function mockPopReport(player: string, year: string, set: string): PopReportResu
     ],
     totalGraded: 3812,
     lastUpdated: new Date().toISOString(),
+    source: 'mock',
+    ...(degradedReason ? { degradedReason } : {}),
   };
 }
 
@@ -124,10 +140,14 @@ export const psaAdapter = {
     return apiCache.getOrFetch(cacheKey, async () => {
       if (isFeatureEnabled('USE_REAL_PSA')) {
         try {
-          return await realCertLookup(certNumber);
+          const result = await realCertLookup(certNumber);
+          return { ...result, source: 'live' as const };
         } catch (err) {
           logger.warn('[PSA] Real API failed, falling back to mock', err);
-          return mockCertLookup(certNumber);
+          return mockCertLookup(
+            certNumber,
+            `Live PSA request failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
       }
       return mockCertLookup(certNumber);
@@ -141,10 +161,14 @@ export const psaAdapter = {
     return apiCache.getOrFetch(cacheKey, async () => {
       if (isFeatureEnabled('USE_REAL_PSA')) {
         try {
-          return await realPopReport(player, year, set);
+          const result = await realPopReport(player, year, set);
+          return { ...result, source: 'live' as const };
         } catch (err) {
           logger.warn('[PSA] Pop report API failed, falling back to mock', err);
-          return mockPopReport(player, year, set);
+          return mockPopReport(
+            player, year, set,
+            `Live PSA request failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
       }
       return mockPopReport(player, year, set);

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -82,7 +82,7 @@ const Login: React.FC = () => {
                                 <Zap className="w-5 h-5 text-brand-lime" />
                             </div>
                             <div>
-                                <h3 className="text-white font-medium mb-1">Real-Time Valuations</h3>
+                                <h2 className="text-white font-medium mb-1 text-base">Real-Time Valuations</h2>
                                 <p className="text-slate-500 text-sm">Track your portfolio with live market data</p>
                             </div>
                         </div>
@@ -91,7 +91,7 @@ const Login: React.FC = () => {
                                 <Shield className="w-5 h-5 text-brand-teal" />
                             </div>
                             <div>
-                                <h3 className="text-white font-medium mb-1">Cloud Sync</h3>
+                                <h2 className="text-white font-medium mb-1 text-base">Cloud Sync</h2>
                                 <p className="text-slate-500 text-sm">Access your collection from any device</p>
                             </div>
                         </div>
@@ -179,7 +179,8 @@ const Login: React.FC = () => {
                                 <button
                                     type="button"
                                     onClick={() => setShowPassword(!showPassword)}
-                                    className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300 transition-colors"
+                                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                                    className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center min-w-[44px] min-h-[44px] text-slate-500 hover:text-slate-300 transition-colors"
                                 >
                                     {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
                                 </button>

--- a/scripts/ci-bundle-gate.cjs
+++ b/scripts/ci-bundle-gate.cjs
@@ -3,10 +3,13 @@
  * Run after `vite build`; exits 1 if any chunk exceeds its budget.
  *
  * Budgets (raw, uncompressed):
- *   index chunk  : 4 MB
- *   lib services : 4.25 MB (intentional shared service chunk)
- *   any other JS : 1.5 MB
- *   total JS     : 12 MB
+ *   index chunk   : 4 MB
+ *   lib-analytics : 2 MB    (largest service domain)
+ *   lib-utils     : 1.75 MB (shared service domain)
+ *   any other JS  : 1.5 MB
+ *   total JS      : 12 MB
+ * Ratchet these DOWN as services migrate or get tree-shaken; never up
+ * without a documented reason.
  */
 'use strict';
 
@@ -14,9 +17,14 @@ const fs = require('fs');
 const path = require('path');
 
 const INDEX_BUDGET_BYTES = 4 * 1024 * 1024; // 4 MB
-const LIB_SERVICES_BUDGET_BYTES = 4.25 * 1024 * 1024; // 4.25 MB
 const CHUNK_BUDGET_BYTES = 1.5 * 1024 * 1024; // 1.5 MB
 const TOTAL_BUDGET_BYTES = 12 * 1024 * 1024; // 12 MB
+
+/** Named chunks with budgets above the generic per-chunk budget. */
+const NAMED_CHUNK_BUDGETS = [
+  { pattern: /^lib-analytics[.-]/, bytes: 2 * 1024 * 1024 },
+  { pattern: /^lib-utils[.-]/, bytes: 1.75 * 1024 * 1024 },
+];
 
 const distAssets = path.join(process.cwd(), 'dist', 'assets');
 
@@ -38,7 +46,11 @@ if (jsFiles.length === 0) {
 }
 
 function logicalChunkName(name) {
-  return name.replace(/-[A-Za-z0-9_-]{8,}\.js$/, '.js');
+  // Vite/rolldown content hashes are exactly 8 base64url chars. The class
+  // includes '-', so an open-ended {8,} quantifier would swallow multi-word
+  // chunk names (lib-analytics-<hash> and lib-utils-<hash> would both
+  // collapse to "lib.js" and the gate would silently skip all but one).
+  return name.replace(/-[A-Za-z0-9_-]{8}\.js$/, '.js');
 }
 
 const latestByLogicalName = new Map();
@@ -68,12 +80,8 @@ console.log(`${'-'.repeat(48)} ${'-'.repeat(9)} ${'-'.repeat(9)} ------`);
 
 for (const { name, size } of budgetedFiles) {
   const isIndex = /^index[.-]/.test(name);
-  const isLibServices = /^lib-services[.-]/.test(name);
-  const budget = isIndex
-    ? INDEX_BUDGET_BYTES
-    : isLibServices
-      ? LIB_SERVICES_BUDGET_BYTES
-      : CHUNK_BUDGET_BYTES;
+  const named = NAMED_CHUNK_BUDGETS.find((b) => b.pattern.test(name));
+  const budget = isIndex ? INDEX_BUDGET_BYTES : named ? named.bytes : CHUNK_BUDGET_BYTES;
   const ok = size <= budget;
   if (!ok) exceeded = true;
   const label = ok ? 'OK' : 'OVER BUDGET ⚠️';

--- a/tests/lib/integrationsSourceHonesty.test.ts
+++ b/tests/lib/integrationsSourceHonesty.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ─── eBay adapter: source honesty + trend ─────────────────────────
+
+describe('ebayAdapter source honesty', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    const { resetFeatureFlags } = await import('../../lib/featureFlags');
+    resetFeatureFlags();
+    const { apiCache } = await import('../../lib/apiCache');
+    apiCache.clear();
+  });
+
+  it('labels mock market data with source: mock and no degradedReason', async () => {
+    const { ebayAdapter } = await import('../../lib/integrations/ebayAdapter');
+    const result = await ebayAdapter.getMarketData({ playerName: 'Mike Trout' });
+    expect(result.source).toBe('mock');
+    expect(result.degradedReason).toBeUndefined();
+  });
+
+  it('labels live-failure fallback with source: mock and a degradedReason', async () => {
+    vi.stubEnv('VITE_FF_USE_REAL_EBAY', 'true');
+    vi.doMock('../../lib/utils/ebayApi', () => ({
+      ebayApi: {
+        getMarketValue: vi.fn().mockRejectedValue(new Error('eBay 503')),
+        searchSportsCards: vi.fn(),
+        testConnection: vi.fn(),
+      },
+    }));
+    const { resetFeatureFlags, isFeatureEnabled } = await import('../../lib/featureFlags');
+    resetFeatureFlags();
+    // Only meaningful when the env actually flips the flag in this harness;
+    // otherwise the mock path is exercised, which is also source: 'mock'.
+    const { ebayAdapter } = await import('../../lib/integrations/ebayAdapter');
+    const result = await ebayAdapter.getMarketData({ playerName: 'Aaron Judge' });
+    expect(result.source).toBe('mock');
+    if (isFeatureEnabled('USE_REAL_EBAY')) {
+      expect(result.degradedReason).toContain('Live eBay request failed');
+    }
+    vi.doUnmock('../../lib/utils/ebayApi');
+  });
+});
+
+describe('computeTrendPercent', () => {
+  it('returns 0 with fewer than 4 sales', async () => {
+    const { computeTrendPercent } = await import('../../lib/integrations/ebayAdapter');
+    expect(computeTrendPercent([])).toBe(0);
+    expect(
+      computeTrendPercent([
+        { price: 10, date: '2026-01-01' },
+        { price: 20, date: '2026-01-02' },
+        { price: 30, date: '2026-01-03' },
+      ]),
+    ).toBe(0);
+  });
+
+  it('computes percent change between older and newer halves', async () => {
+    const { computeTrendPercent } = await import('../../lib/integrations/ebayAdapter');
+    const sales = [
+      { price: 100, date: '2026-01-01' },
+      { price: 100, date: '2026-01-02' },
+      { price: 120, date: '2026-01-10' },
+      { price: 120, date: '2026-01-11' },
+    ];
+    expect(computeTrendPercent(sales)).toBe(20);
+  });
+
+  it('is order-independent (sorts by date internally)', async () => {
+    const { computeTrendPercent } = await import('../../lib/integrations/ebayAdapter');
+    const sales = [
+      { price: 120, date: '2026-01-11' },
+      { price: 100, date: '2026-01-01' },
+      { price: 120, date: '2026-01-10' },
+      { price: 100, date: '2026-01-02' },
+    ];
+    expect(computeTrendPercent(sales)).toBe(20);
+  });
+
+  it('returns negative trend for falling prices', async () => {
+    const { computeTrendPercent } = await import('../../lib/integrations/ebayAdapter');
+    const sales = [
+      { price: 200, date: '2026-01-01' },
+      { price: 200, date: '2026-01-02' },
+      { price: 150, date: '2026-01-10' },
+      { price: 150, date: '2026-01-11' },
+    ];
+    expect(computeTrendPercent(sales)).toBe(-25);
+  });
+});
+
+// ─── PSA adapter: source honesty ──────────────────────────────────
+
+describe('psaAdapter source honesty', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    const { resetFeatureFlags } = await import('../../lib/featureFlags');
+    resetFeatureFlags();
+    const { apiCache } = await import('../../lib/apiCache');
+    apiCache.clear();
+  });
+
+  it('labels mock cert lookups with source: mock', async () => {
+    const { psaAdapter } = await import('../../lib/integrations/psaAdapter');
+    const result = await psaAdapter.verifyCert('12345678');
+    expect(result.source).toBe('mock');
+    expect(result.degradedReason).toBeUndefined();
+    // Mock "verified" is simulated — the source label is what keeps it honest.
+    expect(result.verified).toBe(true);
+  });
+
+  it('labels mock pop reports with source: mock', async () => {
+    const { psaAdapter } = await import('../../lib/integrations/psaAdapter');
+    const result = await psaAdapter.getPopReport('Mike Trout', '2011', 'Topps Update');
+    expect(result.source).toBe('mock');
+    expect(result.totalGraded).toBeGreaterThan(0);
+  });
+});

--- a/tests/lib/integrationsSourceHonesty.test.ts
+++ b/tests/lib/integrationsSourceHonesty.test.ts
@@ -20,7 +20,7 @@ describe('ebayAdapter source honesty', () => {
   });
 
   it('labels live-failure fallback with source: mock and a degradedReason', async () => {
-    vi.stubEnv('VITE_FF_USE_REAL_EBAY', 'true');
+    vi.stubEnv('VITE_FF_REAL_EBAY', 'true');
     vi.doMock('../../lib/utils/ebayApi', () => ({
       ebayApi: {
         getMarketValue: vi.fn().mockRejectedValue(new Error('eBay 503')),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,10 +56,27 @@ export default defineConfig(({ command, mode }) => {
           if (id.includes('node_modules/recharts/') || id.includes('node_modules/d3-') || id.includes('node_modules/victory-vendor/')) {
             return 'recharts-vendor';
           }
-          // Lib services: single chunk to avoid circular dependency (batch1 <-> batch2).
-          // Pages remain lazy-loaded as separate chunks.
-          if (id.includes('/lib/') && /\/lib\/(?:[^/]+\/)?[^/]+Service\.tsx?$/.test(id)) {
-            return 'lib-services';
+          // Lib services: split by domain so a route only pulls the domains it
+          // imports instead of one ~4.3 MB monolith. Bridge files that are
+          // imported across domains are pinned to their consumer's chunk to
+          // keep the chunk graph acyclic:
+          //   trading -> utils only via quantWorkbenchService (no deps of its own)
+          //   core    -> utils only via reportService/taxLotService (reportService's
+          //              sole service dep, collectorAuditDossierService, is in core)
+          // Remaining cross-domain edges form a DAG: utils -> {analytics, trading},
+          // core -> {analytics, trading}, trading -> analytics.
+          const serviceMatch = id.match(/\/lib\/(?:([^/]+)\/)?([^/]+Service)\.tsx?$/);
+          if (serviceMatch && id.includes('/lib/')) {
+            const [, domain, file] = serviceMatch;
+            if (file === 'quantWorkbenchService') return 'lib-trading';
+            if (file === 'reportService' || file === 'taxLotService') return 'lib-core';
+            switch (domain) {
+              case 'analytics': return 'lib-analytics';
+              case 'trading': return 'lib-trading';
+              case 'core': return 'lib-core';
+              case 'social': return 'lib-social';
+              default: return 'lib-utils'; // lib/utils plus root-level re-export shims
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

First implementation wave of the world-class roadmap: performance, accessibility, focus, and data truth — all engineering items that needed no owner-held credentials. The remaining operational items are captured as a checklist in `docs/LAUNCH_OPS_PUNCH_LIST.md`.

### Performance — lib-services monolith split (`vite.config.ts`, `scripts/ci-bundle-gate.cjs`)
- The single `lib-services` chunk (4.36 MB raw / 1.16 MB gzip, loaded by any route touching one service) is now five domain chunks: `lib-analytics` (393 KB gz), `lib-utils` (337 KB), `lib-trading` (173 KB), `lib-core`, `lib-social`. Three cross-domain bridge files are pinned to their consumers' chunks to keep the chunk graph acyclic (mapped the full cross-domain import graph first).
- Fixed a latent bundle-gate bug: the stale-asset regex `-[A-Za-z0-9_-]{8,}\.js$` swallowed multi-word chunk names, collapsing `lib-analytics-<hash>` and `lib-utils-<hash>` to the same logical name — the gate was silently skipping chunks and undercounting totals. Hashes are exactly 8 base64url chars.

### Accessibility — Lighthouse gate unblocked (`pages/Login.tsx`)
- Lighthouse has been failing on main (a11y 0.78 < 0.9). Root causes, found by running lhci locally: password show/hide toggle had no accessible name (weight 10) and an undersized hit target (weight 7); branding-panel `h3`s skipped heading order (weight 3).
- Fixed all three; verified locally with lhci — the accessibility error assertion no longer fires.

### Focus — Labs boundary enforced at the router (`App.tsx`, `.env.e2e`, `ci.yml`)
- `lib/productionLaunch.ts` defined the MVP surface but nothing enforced it; all 330 routes were navigable in production. The long tail now mounts only when `VITE_FF_ENABLE_BETA_SURFACES` is set (dev builds keep everything). Production ships the curated surface per `docs/MVP_LAUNCH_SCOPE.md`.
- CI builds set the flag so the 223-route smoke / a11y / visual jobs still exercise the full surface; `.env.e2e` sets it so Labs-route E2E specs keep running.

### Data truth — adapter source honesty (`lib/integrations/ebayAdapter.ts`, `psaAdapter.ts`)
- Both adapters silently substituted mock data on live-API failure — fabricated comps and simulated PSA "verified" results were indistinguishable from real ones. Responses now carry `source: 'live' | 'mock'` plus `degradedReason` on degraded fallback.
- `trendPercent` is computed from sale history instead of the hardcoded `0 // TODO`.
- New unit tests (`tests/lib/integrationsSourceHonesty.test.ts`) cover mock labeling, degraded fallback, and trend math.

### Ops — owner punch list (`docs/LAUNCH_OPS_PUNCH_LIST.md`)
- RLS verification with real tier users, Sentry DSN, deployed-E2E secret, uptime, real-data API keys, Stripe lifecycle smoke, GDPR endpoint verification — with exact commands and checkboxes.

## Test plan

- [x] `npm run typecheck` + `typecheck:strict` clean
- [x] Full unit suite: 2516 passed (includes 8 new adapter tests)
- [x] `npm run test:e2e:smoke` green locally with Labs gating active
- [x] `npm run ci:bundle` green; total 11.22 MB / 12 MB budget, every chunk within budget
- [x] lhci locally: a11y error assertion cleared on `/#/login`
- [x] `node scripts/check-routes.cjs`: all 330 routes still statically present (gating is runtime-only)
- [ ] CI: Lighthouse audit should flip green for the first time
- [ ] After merge: confirm production Vercel deploy hides Labs routes (flag unset) and Dashboard loads only `lib-utils` + needed domains in DevTools network panel

---
_Generated by [Claude Code](https://claude.ai/code/session_018hCMpkBFW8uixhGMNUgGK4)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split lib-services bundle by domain, add adapter source labeling, and fix Labs route gating
> - Replaces the single `lib-services` Vite chunk with domain-split chunks (`lib-analytics`, `lib-trading`, `lib-core`, `lib-social`, `lib-utils`) in [vite.config.ts](https://github.com/hondoentertainment/ModernSportsIntelligenceDemo/pull/67/files#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890dd); updates [ci-bundle-gate.cjs](https://github.com/hondoentertainment/ModernSportsIntelligenceDemo/pull/67/files#diff-b505610fd1ffc472bb5aef108525732abd680c15660a6409be308700f51402bd) with per-chunk budgets to match.
> - Gates all long-tail Labs routes on the `VITE_FF_ENABLE_BETA_SURFACES` feature flag (or dev mode) in [App.tsx](https://github.com/hondoentertainment/ModernSportsIntelligenceDemo/pull/67/files#diff-a369d17a5dcc6a08663afe8ec644ed0ebc2624f39b704924078c01fd52c58fa3); `/frontier-lab` mounts unconditionally. Enables the flag in CI and E2E environments.
> - Adds `source: 'live' | 'mock'` and `degradedReason` to eBay and PSA adapter return types; live failures now fall back to mock data with a degradation reason rather than throwing.
> - Fixes heading hierarchy and adds `aria-label` to the password toggle in [Login.tsx](https://github.com/hondoentertainment/ModernSportsIntelligenceDemo/pull/67/files#diff-bfb047d3adfea2fee9392dd2715c6022712a4a65458c6dc2521a8942468be848).
> - Behavioral Change: runtime chunk names change from `lib-services` to domain-specific names, and any CI builds exceeding the new per-chunk budgets will fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0eef4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->